### PR TITLE
feat: add wallet.crewai_tool for CrewAI integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = ["pydantic", "httpx"]
 
 [project.optional-dependencies]
 langgraph = ["langchain-core>=0.2"]
+crewai = ["crewai>=0.80", "langchain-core>=0.2"]
 live = ["langgraph>=0.2", "langchain-anthropic>=0.2", "langchain-openai>=0.2"]
 x402 = ["x402[httpx,evm,svm]"]
 docs = ["mkdocs-material", "mkdocstrings[python]"]

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -284,6 +284,44 @@ class AgentWallet:
         return receipt.response_body
 
     @cached_property
+    def crewai_tool(self):
+        """CrewAI-compatible tool for virtual card spends.
+
+        CrewAI natively accepts LangChain tools, so this wraps ``spend_tool``
+        and returns it as a CrewAI ``Tool`` instance for a cleaner integration
+        experience.
+
+        Requires ``crewai`` and ``langchain-core``:
+        install with ``pip install paygraph[crewai]``.
+
+        Example::
+
+            from crewai import Agent, Task, Crew
+            from paygraph import AgentWallet
+
+            wallet = AgentWallet()
+            agent = Agent(
+                role="Purchasing Agent",
+                goal="Buy things",
+                tools=[wallet.crewai_tool],
+            )
+        """
+        try:
+            from crewai.tools import Tool  # type: ignore[import]
+        except ImportError:
+            raise ImportError(
+                "CrewAI integration requires crewai. "
+                "Install it with: pip install paygraph[crewai]"
+            )
+
+        lc_tool = self.spend_tool
+        return Tool(
+            name=lc_tool.name,
+            description=lc_tool.description,
+            func=lc_tool.run,
+        )
+
+    @cached_property
     def x402_tool(self):
         """LangChain-compatible tool for x402 HTTP payments.
 

--- a/tests/test_crewai.py
+++ b/tests/test_crewai.py
@@ -1,0 +1,48 @@
+"""Tests for the CrewAI integration (wallet.crewai_tool)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from paygraph import AgentWallet
+from paygraph.gateways.mock import MockGateway
+
+
+class TestCrewAITool:
+    """Test wallet.crewai_tool integration."""
+
+    def test_crewai_tool_raises_import_error_without_crewai(self):
+        """crewai_tool raises a helpful ImportError when crewai is not installed."""
+        wallet = AgentWallet(gateway=MockGateway(auto_approve=True))
+
+        with patch.dict("sys.modules", {"crewai": None, "crewai.tools": None}):
+            # Clear cached property so it re-evaluates
+            wallet.__dict__.pop("crewai_tool", None)
+            with pytest.raises(ImportError, match="pip install paygraph\\[crewai\\]"):
+                _ = wallet.crewai_tool
+
+    def test_crewai_tool_returns_tool_with_correct_metadata(self):
+        """crewai_tool wraps spend_tool and exposes name and description."""
+        mock_crewai_tool_cls = MagicMock()
+        mock_tool_instance = MagicMock()
+        mock_crewai_tool_cls.return_value = mock_tool_instance
+
+        mock_crewai = MagicMock()
+        mock_crewai.tools = MagicMock()
+        mock_crewai.tools.Tool = mock_crewai_tool_cls
+
+        wallet = AgentWallet(gateway=MockGateway(auto_approve=True))
+        # Clear cached properties
+        wallet.__dict__.pop("crewai_tool", None)
+        wallet.__dict__.pop("spend_tool", None)
+
+        with patch.dict("sys.modules", {"crewai": mock_crewai, "crewai.tools": mock_crewai.tools}):
+            tool = wallet.crewai_tool
+
+        # Verify CrewAI Tool was constructed with the right args
+        mock_crewai_tool_cls.assert_called_once()
+        call_kwargs = mock_crewai_tool_cls.call_args.kwargs
+        assert call_kwargs["name"] == "mint_virtual_card"
+        assert "spend" in call_kwargs["description"].lower() or "purchase" in call_kwargs["description"].lower() or "money" in call_kwargs["description"].lower()
+        assert callable(call_kwargs["func"])
+        assert tool is mock_tool_instance


### PR DESCRIPTION
## Summary
Closes #1

Adds a `crewai_tool` property to `AgentWallet` so CrewAI developers can use PayGraph with the same one-liner experience as LangGraph.

## Changes
- `wallet.py`: Added `crewai_tool` cached property that wraps `spend_tool` as a CrewAI `Tool` instance
- `pyproject.toml`: Added `crewai` optional dependency group (`pip install paygraph[crewai]`)
- `tests/test_crewai.py`: Tests for import error handling and correct tool metadata

## Usage
```python
from crewai import Agent
from paygraph import AgentWallet

wallet = AgentWallet()
agent = Agent(
    role="Purchasing Agent",
    goal="Buy things efficiently",
    tools=[wallet.crewai_tool],
)
```

## Notes
CrewAI natively accepts LangChain tools. This wrapper provides a clean integration point and a dedicated install extra.