### PR TITLE
fix: budget rollback on gateway failure + Slack human-in-the-loop approval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ langgraph = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.80", "langchain-core>=0.2"]
 live = ["langgraph>=0.2", "langchain-anthropic>=0.2", "langchain-openai>=0.2"]
 x402 = ["x402[httpx,evm,svm]"]
-slack = ["slack-sdk>=3.0"]
 docs = ["mkdocs-material", "mkdocstrings[python]"]
 dev = ["ruff>=0.4", "pytest>=8.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ langgraph = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.80", "langchain-core>=0.2"]
 live = ["langgraph>=0.2", "langchain-anthropic>=0.2", "langchain-openai>=0.2"]
 x402 = ["x402[httpx,evm,svm]"]
+slack = ["slack-sdk>=3.0"]
 docs = ["mkdocs-material", "mkdocstrings[python]"]
 dev = ["ruff>=0.4", "pytest>=8.0"]
 

--- a/src/paygraph/__init__.py
+++ b/src/paygraph/__init__.py
@@ -1,5 +1,6 @@
 from paygraph.exceptions import (
     GatewayError,
+    HumanApprovalRequired,
     PayGraphError,
     PolicyViolationError,
     SpendDeniedError,
@@ -7,6 +8,7 @@ from paygraph.exceptions import (
 from paygraph.gateways.base import BaseGateway, VirtualCard
 from paygraph.gateways.mock import MockGateway
 from paygraph.gateways.mock_x402 import MockX402Gateway
+from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.gateways.stripe import StripeCardGateway
 from paygraph.gateways.stripe_mpp import StripeMPPGateway
 from paygraph.gateways.x402 import X402Gateway, X402Receipt
@@ -21,6 +23,7 @@ __all__ = [
     "StripeCardGateway",
     "StripeMPPGateway",
     "MockGateway",
+    "SlackApprovalGateway",
     "X402Gateway",
     "X402Receipt",
     "MockX402Gateway",
@@ -28,4 +31,5 @@ __all__ = [
     "SpendDeniedError",
     "PolicyViolationError",
     "GatewayError",
+    "HumanApprovalRequired",
 ]

--- a/src/paygraph/exceptions.py
+++ b/src/paygraph/exceptions.py
@@ -12,3 +12,22 @@ class PolicyViolationError(PayGraphError):
 
 class GatewayError(PayGraphError):
     """Gateway API call failed."""
+
+
+class HumanApprovalRequired(PayGraphError):
+    """Spend requires human approval via Slack before proceeding.
+
+    Attributes:
+        request_id: Unique ID for this pending approval (use to resume).
+        amount: Dollar amount awaiting approval.
+        vendor: Vendor name awaiting approval.
+    """
+
+    def __init__(self, request_id: str, amount: float, vendor: str) -> None:
+        self.request_id = request_id
+        self.amount = amount
+        self.vendor = vendor
+        super().__init__(
+            f"Spend of ${amount:.2f} for '{vendor}' requires human approval "
+            f"(request_id={request_id})"
+        )

--- a/src/paygraph/gateways/__init__.py
+++ b/src/paygraph/gateways/__init__.py
@@ -1,5 +1,6 @@
 from paygraph.gateways.base import BaseGateway, VirtualCard
 from paygraph.gateways.mock import MockGateway
+from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.gateways.stripe import StripeCardGateway
 from paygraph.gateways.stripe_mpp import StripeMPPGateway
 
@@ -9,4 +10,5 @@ __all__ = [
     "StripeCardGateway",
     "StripeMPPGateway",
     "MockGateway",
+    "SlackApprovalGateway",
 ]

--- a/src/paygraph/gateways/slack.py
+++ b/src/paygraph/gateways/slack.py
@@ -1,0 +1,153 @@
+import secrets
+
+import httpx
+
+from paygraph.exceptions import HumanApprovalRequired, SpendDeniedError
+from paygraph.gateways.base import BaseGateway, VirtualCard
+
+
+class SlackApprovalGateway(BaseGateway):
+    """Gateway that fires a Slack webhook for human approval before spending.
+
+    Wraps an inner gateway (e.g. ``MockGateway``, ``StripeCardGateway``).
+    When ``request_approval()`` is called, it posts an Approve/Deny message
+    to Slack and raises ``HumanApprovalRequired``. The caller must store the
+    ``request_id`` and later call ``complete_spend()`` once the human responds.
+
+    Example::
+
+        from paygraph import AgentWallet, SpendPolicy
+        from paygraph.gateways.slack import SlackApprovalGateway
+        from paygraph.gateways.mock import MockGateway
+        from paygraph.exceptions import HumanApprovalRequired
+
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/services/...",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        wallet = AgentWallet(
+            gateway=gateway,
+            policy=SpendPolicy(require_human_approval_above=20.0),
+        )
+
+        try:
+            wallet.request_spend(50.0, "Anthropic", "need tokens")
+        except HumanApprovalRequired as e:
+            # Store e.request_id — resume later when human responds
+            result = wallet.complete_spend(e.request_id, approved=True)
+    """
+
+    def __init__(self, webhook_url: str, inner_gateway: BaseGateway) -> None:
+        """Initialise the Slack approval gateway.
+
+        Args:
+            webhook_url: Slack incoming webhook URL to post approval requests to.
+            inner_gateway: Gateway used to execute the spend once approved.
+        """
+        self.webhook_url = webhook_url
+        self.inner_gateway = inner_gateway
+        self._pending: dict[str, dict] = {}
+
+    def request_approval(self, amount_cents: int, vendor: str, memo: str) -> None:
+        """Post an approval request to Slack and raise ``HumanApprovalRequired``.
+
+        Args:
+            amount_cents: Spend amount in cents.
+            vendor: Vendor name.
+            memo: Justification for the spend.
+
+        Raises:
+            HumanApprovalRequired: Always — after successfully posting to Slack.
+            GatewayError: If the Slack webhook POST fails.
+        """
+        request_id = secrets.token_hex(8)
+        amount_dollars = amount_cents / 100
+
+        payload = {
+            "text": (
+                f"*PayGraph Approval Required*\n"
+                f"Amount: *${amount_dollars:.2f}*\n"
+                f"Vendor: *{vendor}*\n"
+                f"Justification: {memo}\n"
+                f"Request ID: `{request_id}`"
+            ),
+            "attachments": [
+                {
+                    "fallback": "Approve or Deny this spend request",
+                    "callback_id": request_id,
+                    "actions": [
+                        {
+                            "name": "approve",
+                            "text": "Approve",
+                            "type": "button",
+                            "value": "approve",
+                            "style": "primary",
+                        },
+                        {
+                            "name": "deny",
+                            "text": "Deny",
+                            "type": "button",
+                            "value": "deny",
+                            "style": "danger",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        httpx.post(self.webhook_url, json=payload, timeout=10)
+        self._pending[request_id] = {
+            "amount_cents": amount_cents,
+            "vendor": vendor,
+            "memo": memo,
+        }
+        raise HumanApprovalRequired(request_id, amount_dollars, vendor)
+
+    def execute_spend(self, amount_cents: int, vendor: str, memo: str) -> VirtualCard:
+        """Execute a spend directly via the inner gateway (below-threshold path).
+
+        Args:
+            amount_cents: Spend amount in cents.
+            vendor: Vendor name.
+            memo: Justification for the spend.
+
+        Returns:
+            A ``VirtualCard`` from the inner gateway.
+        """
+        return self.inner_gateway.execute_spend(amount_cents, vendor, memo)
+
+    def complete_spend(self, request_id: str, approved: bool) -> VirtualCard:
+        """Resume a pending spend after a human has responded in Slack.
+
+        Args:
+            request_id: The ``request_id`` from the ``HumanApprovalRequired``
+                exception raised by ``request_approval()``.
+            approved: ``True`` if the human approved, ``False`` if denied.
+
+        Returns:
+            A ``VirtualCard`` from the inner gateway if approved.
+
+        Raises:
+            SpendDeniedError: If ``approved`` is ``False``.
+            KeyError: If ``request_id`` is unknown or already completed.
+        """
+        pending = self._pending.pop(request_id)
+        if not approved:
+            raise SpendDeniedError(
+                f"Human denied spend of ${pending['amount_cents'] / 100:.2f} "
+                f"for {pending['vendor']}"
+            )
+        return self.inner_gateway.execute_spend(
+            pending["amount_cents"], pending["vendor"], pending["memo"]
+        )
+
+    def revoke(self, gateway_ref: str) -> bool:
+        """Revoke a card via the inner gateway.
+
+        Args:
+            gateway_ref: The ``gateway_ref`` of the card to revoke.
+
+        Returns:
+            ``True`` if the card was revoked, ``False`` otherwise.
+        """
+        return self.inner_gateway.revoke(gateway_ref)

--- a/src/paygraph/gateways/slack.py
+++ b/src/paygraph/gateways/slack.py
@@ -2,7 +2,7 @@ import secrets
 
 import httpx
 
-from paygraph.exceptions import HumanApprovalRequired, SpendDeniedError
+from paygraph.exceptions import GatewayError, HumanApprovalRequired, SpendDeniedError
 from paygraph.gateways.base import BaseGateway, VirtualCard
 
 
@@ -48,13 +48,20 @@ class SlackApprovalGateway(BaseGateway):
         self.inner_gateway = inner_gateway
         self._pending: dict[str, dict] = {}
 
-    def request_approval(self, amount_cents: int, vendor: str, memo: str) -> None:
+    def request_approval(
+        self, amount_cents: int, vendor: str, memo: str, justification: str | None = None
+    ) -> None:
         """Post an approval request to Slack and raise ``HumanApprovalRequired``.
+
+        Posts a plain-text notification to the configured incoming webhook URL.
+        Note: incoming webhooks do not support interactive callbacks — wire up
+        a full Slack app with interactivity enabled if you need button responses.
 
         Args:
             amount_cents: Spend amount in cents.
             vendor: Vendor name.
             memo: Justification for the spend.
+            justification: Original justification string (stored for audit log).
 
         Raises:
             HumanApprovalRequired: Always — after successfully posting to Slack.
@@ -69,37 +76,21 @@ class SlackApprovalGateway(BaseGateway):
                 f"Amount: *${amount_dollars:.2f}*\n"
                 f"Vendor: *{vendor}*\n"
                 f"Justification: {memo}\n"
-                f"Request ID: `{request_id}`"
+                f"Request ID: `{request_id}`\n"
+                f"Reply with `approve {request_id}` or `deny {request_id}`."
             ),
-            "attachments": [
-                {
-                    "fallback": "Approve or Deny this spend request",
-                    "callback_id": request_id,
-                    "actions": [
-                        {
-                            "name": "approve",
-                            "text": "Approve",
-                            "type": "button",
-                            "value": "approve",
-                            "style": "primary",
-                        },
-                        {
-                            "name": "deny",
-                            "text": "Deny",
-                            "type": "button",
-                            "value": "deny",
-                            "style": "danger",
-                        },
-                    ],
-                }
-            ],
         }
 
-        httpx.post(self.webhook_url, json=payload, timeout=10)
+        try:
+            httpx.post(self.webhook_url, json=payload, timeout=10)
+        except Exception as e:
+            raise GatewayError(f"Slack webhook POST failed: {e}") from e
+
         self._pending[request_id] = {
             "amount_cents": amount_cents,
             "vendor": vendor,
             "memo": memo,
+            "justification": justification,
         }
         raise HumanApprovalRequired(request_id, amount_dollars, vendor)
 
@@ -140,6 +131,17 @@ class SlackApprovalGateway(BaseGateway):
         return self.inner_gateway.execute_spend(
             pending["amount_cents"], pending["vendor"], pending["memo"]
         )
+
+    def get_pending(self, request_id: str) -> dict:
+        """Return a pending request's metadata without removing it.
+
+        Used by ``AgentWallet.complete_spend()`` to retrieve vendor/justification
+        for audit logging before calling ``complete_spend()``.
+
+        Raises:
+            KeyError: If ``request_id`` is unknown.
+        """
+        return self._pending[request_id]
 
     def revoke(self, gateway_ref: str) -> bool:
         """Revoke a card via the inner gateway.

--- a/src/paygraph/gateways/slack.py
+++ b/src/paygraph/gateways/slack.py
@@ -49,7 +49,11 @@ class SlackApprovalGateway(BaseGateway):
         self._pending: dict[str, dict] = {}
 
     def request_approval(
-        self, amount_cents: int, vendor: str, memo: str, justification: str | None = None
+        self,
+        amount_cents: int,
+        vendor: str,
+        memo: str,
+        justification: str | None = None,
     ) -> None:
         """Post an approval request to Slack and raise ``HumanApprovalRequired``.
 

--- a/src/paygraph/policy.py
+++ b/src/paygraph/policy.py
@@ -17,6 +17,8 @@ class SpendPolicy:
         allowed_mccs: Merchant Category Code allowlist (reserved for future use).
         require_justification: Whether a justification string is required
             for every spend request.
+        require_human_approval_above: If set, spends above this dollar amount
+            require human approval via Slack before the gateway is called.
     """
 
     max_transaction: float = 50.0
@@ -25,6 +27,7 @@ class SpendPolicy:
     blocked_vendors: list[str] | None = None
     allowed_mccs: list[int] | None = None
     require_justification: bool = True
+    require_human_approval_above: float | None = None
 
 
 @dataclass

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -1,8 +1,9 @@
 from functools import cached_property
 
 from paygraph.audit import AuditLogger, AuditRecord
-from paygraph.exceptions import GatewayError, PolicyViolationError, SpendDeniedError
+from paygraph.exceptions import GatewayError, HumanApprovalRequired, PolicyViolationError, SpendDeniedError
 from paygraph.gateways.mock import MockGateway
+from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.policy import PolicyEngine, SpendPolicy
 
 
@@ -73,6 +74,10 @@ class AgentWallet:
             PolicyViolationError: If the policy engine denies the request.
             SpendDeniedError: If a human denies the request (MockGateway).
             GatewayError: If the gateway API call fails.
+            HumanApprovalRequired: If the amount exceeds
+                ``policy.require_human_approval_above`` and a
+                ``SlackApprovalGateway`` is configured. Resume with
+                ``complete_spend(request_id, approved=True)``.
         """
         # Print header and run policy engine with live check output
         on_check = (
@@ -96,8 +101,27 @@ class AgentWallet:
             )
             raise PolicyViolationError(result.denial_reason)
 
-        # Mint card — commit the budget only after the gateway succeeds
+        # Human approval via Slack (if threshold is configured and gateway supports it)
         amount_cents = int(round(amount * 100))
+        if (
+            self.policy_engine.policy.require_human_approval_above is not None
+            and amount > self.policy_engine.policy.require_human_approval_above
+            and isinstance(self.gateway, SlackApprovalGateway)
+        ):
+            self._audit.log(
+                AuditRecord.now(
+                    agent_id=self.agent_id,
+                    amount=amount,
+                    vendor=vendor,
+                    justification=justification,
+                    policy_result="pending_approval",
+                    checks_passed=result.checks_passed,
+                )
+            )
+            self.gateway.request_approval(amount_cents, vendor, justification)
+            # request_approval always raises HumanApprovalRequired — unreachable
+
+        # Mint card — commit the budget only after the gateway succeeds
         try:
             card = self.gateway.execute_spend(amount_cents, vendor, justification)
         except SpendDeniedError:
@@ -150,6 +174,51 @@ class AgentWallet:
             )
 
         return f"Card approved. PAN: {card.pan}, CVV: {card.cvv}, Expiry: {card.expiry}"
+
+    def complete_spend(self, request_id: str, approved: bool) -> str:
+        """Resume a spend that was paused for human Slack approval.
+
+        Call this after catching ``HumanApprovalRequired`` from
+        ``request_spend()`` and receiving the human's response.
+
+        Args:
+            request_id: The ``request_id`` from the ``HumanApprovalRequired``
+                exception.
+            approved: ``True`` to approve the spend, ``False`` to deny it.
+
+        Returns:
+            Card details string if approved (same format as ``request_spend``).
+
+        Raises:
+            GatewayError: If no ``SlackApprovalGateway`` is configured.
+            SpendDeniedError: If ``approved`` is ``False``.
+        """
+        if not isinstance(self.gateway, SlackApprovalGateway):
+            raise GatewayError("complete_spend requires a SlackApprovalGateway.")
+
+        card = self.gateway.complete_spend(request_id, approved)
+        self._audit.log(
+            AuditRecord.now(
+                agent_id=self.agent_id,
+                amount=card.spend_limit_cents / 100,
+                vendor="(resumed)",
+                justification=None,
+                policy_result="approved",
+                gateway_ref=card.gateway_ref,
+                gateway_type=card.gateway_type,
+            )
+        )
+
+        if card.gateway_type.startswith("stripe_mpp"):
+            return (
+                f"SPT approved. Token: {card.gateway_ref} "
+                f"(spend limit: ${card.spend_limit_cents / 100:.2f})"
+            )
+
+        return (
+            f"Card approved. PAN: {card.pan}, CVV: {card.cvv}, "
+            f"Expiry: {card.expiry}"
+        )
 
     @cached_property
     def spend_tool(self):
@@ -381,6 +450,7 @@ class AgentWallet:
                 headers=headers,
                 body=body,
             )
+            self.policy_engine.commit_spend(amount)
         except SpendDeniedError:
             self._audit.log(
                 AuditRecord.now(

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -208,7 +208,21 @@ class AgentWallet:
         vendor = pending["vendor"]
         justification = pending["justification"]
 
-        card = self.gateway.complete_spend(request_id, approved)
+        try:
+            card = self.gateway.complete_spend(request_id, approved)
+        except SpendDeniedError:
+            self._audit.log(
+                AuditRecord.now(
+                    agent_id=self.agent_id,
+                    amount=amount,
+                    vendor=vendor,
+                    justification=justification,
+                    policy_result="denied",
+                    denial_reason=f"Human denied spend of ${amount:.2f} for {vendor}",
+                )
+            )
+            raise
+
         self.policy_engine.commit_spend(amount)
         self._audit.log(
             AuditRecord.now(
@@ -459,7 +473,6 @@ class AgentWallet:
                 headers=headers,
                 body=body,
             )
-            self.policy_engine.commit_spend(amount)
         except SpendDeniedError:
             self._audit.log(
                 AuditRecord.now(
@@ -486,6 +499,8 @@ class AgentWallet:
                 )
             )
             raise GatewayError(str(e)) from e
+
+        self.policy_engine.commit_spend(amount)
 
         self._audit.log(
             AuditRecord.now(

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -118,7 +118,7 @@ class AgentWallet:
                     checks_passed=result.checks_passed,
                 )
             )
-            self.gateway.request_approval(amount_cents, vendor, justification)
+            self.gateway.request_approval(amount_cents, vendor, justification, justification=justification)
             # request_approval always raises HumanApprovalRequired — unreachable
 
         # Mint card — commit the budget only after the gateway succeeds
@@ -196,13 +196,20 @@ class AgentWallet:
         if not isinstance(self.gateway, SlackApprovalGateway):
             raise GatewayError("complete_spend requires a SlackApprovalGateway.")
 
+        # Peek at pending metadata before complete_spend() pops it
+        pending = self.gateway.get_pending(request_id)
+        amount = pending["amount_cents"] / 100
+        vendor = pending["vendor"]
+        justification = pending["justification"]
+
         card = self.gateway.complete_spend(request_id, approved)
+        self.policy_engine.commit_spend(amount)
         self._audit.log(
             AuditRecord.now(
                 agent_id=self.agent_id,
-                amount=card.spend_limit_cents / 100,
-                vendor="(resumed)",
-                justification=None,
+                amount=amount,
+                vendor=vendor,
+                justification=justification,
                 policy_result="approved",
                 gateway_ref=card.gateway_ref,
                 gateway_type=card.gateway_type,
@@ -212,7 +219,7 @@ class AgentWallet:
         if card.gateway_type.startswith("stripe_mpp"):
             return (
                 f"SPT approved. Token: {card.gateway_ref} "
-                f"(spend limit: ${card.spend_limit_cents / 100:.2f})"
+                f"(spend limit: ${amount:.2f})"
             )
 
         return (

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -1,7 +1,11 @@
 from functools import cached_property
 
 from paygraph.audit import AuditLogger, AuditRecord
-from paygraph.exceptions import GatewayError, HumanApprovalRequired, PolicyViolationError, SpendDeniedError
+from paygraph.exceptions import (
+    GatewayError,
+    PolicyViolationError,
+    SpendDeniedError,
+)
 from paygraph.gateways.mock import MockGateway
 from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.policy import PolicyEngine, SpendPolicy
@@ -118,7 +122,9 @@ class AgentWallet:
                     checks_passed=result.checks_passed,
                 )
             )
-            self.gateway.request_approval(amount_cents, vendor, justification, justification=justification)
+            self.gateway.request_approval(
+                amount_cents, vendor, justification, justification=justification
+            )
             # request_approval always raises HumanApprovalRequired — unreachable
 
         # Mint card — commit the budget only after the gateway succeeds
@@ -218,14 +224,10 @@ class AgentWallet:
 
         if card.gateway_type.startswith("stripe_mpp"):
             return (
-                f"SPT approved. Token: {card.gateway_ref} "
-                f"(spend limit: ${amount:.2f})"
+                f"SPT approved. Token: {card.gateway_ref} (spend limit: ${amount:.2f})"
             )
 
-        return (
-            f"Card approved. PAN: {card.pan}, CVV: {card.cvv}, "
-            f"Expiry: {card.expiry}"
-        )
+        return f"Card approved. PAN: {card.pan}, CVV: {card.cvv}, Expiry: {card.expiry}"
 
     @cached_property
     def spend_tool(self):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -126,7 +126,6 @@ class TestDailyBudget:
         engine = PolicyEngine(SpendPolicy(max_transaction=100.0, daily_budget=100.0))
         r1 = engine.evaluate(60.0, "vendor", "reason")
         assert r1.approved
-        # Simulate a successful gateway: commit the spend before the next check
         engine.commit_spend(60.0)
         r2 = engine.evaluate(50.0, "vendor", "reason")
         assert not r2.approved
@@ -160,6 +159,25 @@ class TestDailyBudget:
             mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
             result = engine.evaluate(80.0, "vendor", "reason")
             assert result.approved
+
+
+class TestCommitSpend:
+    def test_evaluate_does_not_increment_before_commit(self):
+        engine = PolicyEngine(SpendPolicy(max_transaction=100.0, daily_budget=100.0))
+        result = engine.evaluate(60.0, "vendor", "reason")
+        assert result.approved
+        # Without commit, budget is still 0 — second call still passes
+        result2 = engine.evaluate(60.0, "vendor", "reason")
+        assert result2.approved
+
+    def test_commit_spend_increments_budget(self):
+        engine = PolicyEngine(SpendPolicy(max_transaction=100.0, daily_budget=100.0))
+        engine.evaluate(60.0, "vendor", "reason")
+        engine.commit_spend(60.0)
+        # Now budget is consumed — next call should fail
+        result = engine.evaluate(50.0, "vendor", "reason")
+        assert not result.approved
+        assert "Daily budget exhausted" in result.denial_reason
 
 
 class TestJustification:

--- a/tests/test_slack_gateway.py
+++ b/tests/test_slack_gateway.py
@@ -1,0 +1,213 @@
+import json
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from paygraph.exceptions import GatewayError, HumanApprovalRequired, SpendDeniedError
+from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.mock import MockGateway
+from paygraph.gateways.slack import SlackApprovalGateway
+from paygraph.policy import SpendPolicy
+from paygraph.wallet import AgentWallet
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_slack_wallet(
+    webhook_url: str = "https://hooks.slack.com/test",
+    inner_gateway=None,
+    policy=None,
+    **kwargs,
+) -> tuple[AgentWallet, str]:
+    """Create a wallet backed by a SlackApprovalGateway. Returns (wallet, audit_path)."""
+    f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+    f.close()
+    gateway = SlackApprovalGateway(
+        webhook_url=webhook_url,
+        inner_gateway=inner_gateway or MockGateway(auto_approve=True),
+    )
+    wallet = AgentWallet(
+        gateway=gateway,
+        policy=policy or SpendPolicy(require_human_approval_above=20.0),
+        log_path=f.name,
+        verbose=False,
+        **kwargs,
+    )
+    return wallet, f.name
+
+
+def _read_audit(path: str) -> list[dict]:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# SlackApprovalGateway unit tests
+# ---------------------------------------------------------------------------
+
+class TestSlackApprovalGateway:
+    def test_request_approval_raises_human_approval_required(self):
+        """Posting to webhook raises HumanApprovalRequired with correct fields."""
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                gateway.request_approval(5000, "Anthropic", "need tokens")
+
+        err = exc_info.value
+        assert err.amount == 50.0
+        assert err.vendor == "Anthropic"
+        assert err.request_id  # non-empty string
+
+    def test_request_approval_posts_to_slack(self):
+        """Slack webhook is called with correct URL and payload."""
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            with pytest.raises(HumanApprovalRequired):
+                gateway.request_approval(5000, "Anthropic", "need tokens")
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[0][0] == "https://hooks.slack.com/test"
+        payload = call_kwargs[1]["json"]
+        assert "Anthropic" in payload["text"]
+        assert "$50.00" in payload["text"]
+
+    def test_complete_spend_approved_returns_card(self):
+        """approved=True delegates to inner gateway and returns a VirtualCard."""
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                gateway.request_approval(5000, "Anthropic", "need tokens")
+
+        request_id = exc_info.value.request_id
+        card = gateway.complete_spend(request_id, approved=True)
+        assert isinstance(card, VirtualCard)
+        assert card.pan == "4111111111111111"
+
+    def test_complete_spend_denied_raises_spend_denied_error(self):
+        """approved=False raises SpendDeniedError."""
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                gateway.request_approval(5000, "Anthropic", "need tokens")
+
+        request_id = exc_info.value.request_id
+        with pytest.raises(SpendDeniedError):
+            gateway.complete_spend(request_id, approved=False)
+
+    def test_unknown_request_id_raises_key_error(self):
+        """complete_spend with an unknown ID raises KeyError."""
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        with pytest.raises(KeyError):
+            gateway.complete_spend("nonexistent_id", approved=True)
+
+    def test_request_id_consumed_after_complete_spend(self):
+        """Completing a spend removes it from pending — cannot resume twice."""
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                gateway.request_approval(5000, "Anthropic", "need tokens")
+
+        request_id = exc_info.value.request_id
+        gateway.complete_spend(request_id, approved=True)
+        with pytest.raises(KeyError):
+            gateway.complete_spend(request_id, approved=True)
+
+
+# ---------------------------------------------------------------------------
+# AgentWallet integration tests
+# ---------------------------------------------------------------------------
+
+class TestWalletSlackFlow:
+    def test_above_threshold_raises_human_approval_required(self):
+        """request_spend above threshold fires Slack and raises HumanApprovalRequired."""
+        wallet, _ = _make_slack_wallet()
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet.request_spend(50.0, "Anthropic", "need tokens")
+
+        assert exc_info.value.amount == 50.0
+        assert exc_info.value.vendor == "Anthropic"
+        assert exc_info.value.request_id
+
+    def test_below_threshold_skips_slack_approval(self):
+        """request_spend at or below threshold goes straight to gateway — no HumanApprovalRequired."""
+        wallet, _ = _make_slack_wallet()
+        # threshold is 20.0, spend 10.0 — should succeed without Slack
+        result = wallet.request_spend(10.0, "Anthropic", "cheap call")
+        assert "Card approved" in result
+
+    def test_above_threshold_audit_records_pending(self):
+        """Audit log records policy_result='pending_approval' for Slack-gated spends."""
+        wallet, path = _make_slack_wallet()
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired):
+                wallet.request_spend(50.0, "Anthropic", "need tokens")
+
+        records = _read_audit(path)
+        assert len(records) == 1
+        assert records[0]["policy_result"] == "pending_approval"
+
+    def test_complete_spend_approved_returns_card_string(self):
+        """complete_spend(approved=True) returns card details string."""
+        wallet, _ = _make_slack_wallet()
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet.request_spend(50.0, "Anthropic", "need tokens")
+
+        result = wallet.complete_spend(exc_info.value.request_id, approved=True)
+        assert "Card approved" in result
+
+    def test_complete_spend_denied_raises_spend_denied(self):
+        """complete_spend(approved=False) raises SpendDeniedError."""
+        wallet, _ = _make_slack_wallet()
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet.request_spend(50.0, "Anthropic", "need tokens")
+
+        with pytest.raises(SpendDeniedError):
+            wallet.complete_spend(exc_info.value.request_id, approved=False)
+
+    def test_complete_spend_without_slack_gateway_raises_gateway_error(self):
+        """complete_spend raises GatewayError if gateway is not SlackApprovalGateway."""
+        f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+        f.close()
+        wallet = AgentWallet(
+            gateway=MockGateway(auto_approve=True),
+            log_path=f.name,
+            verbose=False,
+        )
+        with pytest.raises(GatewayError, match="SlackApprovalGateway"):
+            wallet.complete_spend("some_id", approved=True)
+
+    def test_no_threshold_configured_skips_slack(self):
+        """Without require_human_approval_above, SlackApprovalGateway acts as pass-through."""
+        wallet, _ = _make_slack_wallet(
+            policy=SpendPolicy(require_human_approval_above=None)
+        )
+        # No threshold — should execute directly via inner gateway
+        result = wallet.request_spend(50.0, "Anthropic", "need tokens")
+        assert "Card approved" in result

--- a/tests/test_slack_gateway.py
+++ b/tests/test_slack_gateway.py
@@ -2,6 +2,7 @@ import json
 import tempfile
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from paygraph.exceptions import GatewayError, HumanApprovalRequired, SpendDeniedError
@@ -82,6 +83,19 @@ class TestSlackApprovalGateway:
         payload = call_kwargs[1]["json"]
         assert "Anthropic" in payload["text"]
         assert "$50.00" in payload["text"]
+        # No interactive attachments — incoming webhooks can't receive callbacks
+        assert "attachments" not in payload
+
+    def test_request_approval_wraps_webhook_error_as_gateway_error(self):
+        """If Slack webhook POST fails, raises GatewayError not raw httpx exception."""
+        from paygraph.exceptions import GatewayError
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        with patch("httpx.post", side_effect=httpx.ConnectError("connection refused")):
+            with pytest.raises(GatewayError, match="Slack webhook POST failed"):
+                gateway.request_approval(5000, "Anthropic", "need tokens")
 
     def test_complete_spend_approved_returns_card(self):
         """approved=True delegates to inner gateway and returns a VirtualCard."""
@@ -211,3 +225,41 @@ class TestWalletSlackFlow:
         # No threshold — should execute directly via inner gateway
         result = wallet.request_spend(50.0, "Anthropic", "need tokens")
         assert "Card approved" in result
+
+    def test_complete_spend_commits_budget(self):
+        """complete_spend(approved=True) must commit the spend to the daily budget."""
+        from paygraph.exceptions import PolicyViolationError
+        policy = SpendPolicy(
+            max_transaction=100.0,
+            daily_budget=60.0,
+            require_human_approval_above=20.0,
+        )
+        wallet, _ = _make_slack_wallet(policy=policy)
+
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet.request_spend(50.0, "Anthropic", "need tokens")
+
+        wallet.complete_spend(exc_info.value.request_id, approved=True)
+
+        # Budget is now 50.0 / 60.0 — a second 50.0 exceeds the daily budget
+        # and should be rejected by policy before even reaching Slack
+        assert wallet.policy_engine._daily_spend == 50.0
+        with pytest.raises(PolicyViolationError, match="Daily budget exhausted"):
+            wallet.request_spend(50.0, "Anthropic", "need tokens again")
+
+    def test_complete_spend_audit_has_correct_vendor_and_justification(self):
+        """Audit record from complete_spend uses real vendor/justification, not placeholders."""
+        wallet, path = _make_slack_wallet()
+
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet.request_spend(50.0, "Anthropic", "need tokens for task")
+
+        wallet.complete_spend(exc_info.value.request_id, approved=True)
+
+        records = _read_audit(path)
+        approved_record = next(r for r in records if r["policy_result"] == "approved")
+        assert approved_record["vendor"] == "Anthropic"
+        assert approved_record["justification"] == "need tokens for task"
+        assert approved_record["amount"] == 50.0

--- a/tests/test_slack_gateway.py
+++ b/tests/test_slack_gateway.py
@@ -208,6 +208,23 @@ class TestWalletSlackFlow:
         with pytest.raises(SpendDeniedError):
             wallet.complete_spend(exc_info.value.request_id, approved=False)
 
+    def test_complete_spend_denial_writes_audit_record(self):
+        """complete_spend(approved=False) writes a denial audit record with real metadata."""
+        wallet, path = _make_slack_wallet()
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet.request_spend(50.0, "Anthropic", "need tokens for task")
+
+        with pytest.raises(SpendDeniedError):
+            wallet.complete_spend(exc_info.value.request_id, approved=False)
+
+        records = _read_audit(path)
+        denied = next(r for r in records if r["policy_result"] == "denied")
+        assert denied["vendor"] == "Anthropic"
+        assert denied["justification"] == "need tokens for task"
+        assert denied["amount"] == 50.0
+        assert "Human denied" in denied["denial_reason"]
+
     def test_complete_spend_without_slack_gateway_raises_gateway_error(self):
         """complete_spend raises GatewayError if gateway is not SlackApprovalGateway."""
         f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)

--- a/tests/test_slack_gateway.py
+++ b/tests/test_slack_gateway.py
@@ -6,16 +6,16 @@ import httpx
 import pytest
 
 from paygraph.exceptions import GatewayError, HumanApprovalRequired, SpendDeniedError
-from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.base import VirtualCard
 from paygraph.gateways.mock import MockGateway
 from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.policy import SpendPolicy
 from paygraph.wallet import AgentWallet
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_slack_wallet(
     webhook_url: str = "https://hooks.slack.com/test",
@@ -48,6 +48,7 @@ def _read_audit(path: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 # SlackApprovalGateway unit tests
 # ---------------------------------------------------------------------------
+
 
 class TestSlackApprovalGateway:
     def test_request_approval_raises_human_approval_required(self):
@@ -89,6 +90,7 @@ class TestSlackApprovalGateway:
     def test_request_approval_wraps_webhook_error_as_gateway_error(self):
         """If Slack webhook POST fails, raises GatewayError not raw httpx exception."""
         from paygraph.exceptions import GatewayError
+
         gateway = SlackApprovalGateway(
             webhook_url="https://hooks.slack.com/test",
             inner_gateway=MockGateway(auto_approve=True),
@@ -154,6 +156,7 @@ class TestSlackApprovalGateway:
 # ---------------------------------------------------------------------------
 # AgentWallet integration tests
 # ---------------------------------------------------------------------------
+
 
 class TestWalletSlackFlow:
     def test_above_threshold_raises_human_approval_required(self):
@@ -229,6 +232,7 @@ class TestWalletSlackFlow:
     def test_complete_spend_commits_budget(self):
         """complete_spend(approved=True) must commit the spend to the daily budget."""
         from paygraph.exceptions import PolicyViolationError
+
         policy = SpendPolicy(
             max_transaction=100.0,
             daily_budget=60.0,


### PR DESCRIPTION
 Closes #2 (core flow). Rebased on main so #9's budget-rollback work is already included.

  What this does

  - New HumanApprovalRequired exception + require_human_approval_above field on SpendPolicy
  - New SlackApprovalGateway wraps any inner gateway — posts a webhook above threshold, raises HumanApprovalRequired(request_id, amount, vendor)
  - New wallet.complete_spend(request_id, approved) resumes the paused spend; commits budget and logs audit on approval

  Review fixes (all 5 addressed)

  1. complete_spend() now calls commit_spend() — Slack-approved spends count against the daily budget
  2. Audit log uses real vendor / justification (via new get_pending() peek) instead of "(resumed)"
  3. httpx.post wrapped → raises GatewayError on webhook failure
  4. Non-functional buttons removed; plain-text reply approve <id> with a docstring note
  5. Unused slack-sdk extra dropped from pyproject.toml

  Known follow-ups (out of scope here)

  The issue's "Challenges" list mentions three architectural pieces I've intentionally left for separate PRs:

  - LangGraph interrupt_before integration — this PR is framework-agnostic (exception-based); native LangGraph pause/resume glue is a separate design
  - Async webhook listener — SDK posts and forgets; receiving Slack's response is left to the caller. A built-in FastAPI/aiohttp listener is a non-trivial
  stateful component
  - Timeout handling — pending entries live in-memory forever; needs a TTL sweeper or external store

  Happy to open follow-up issues for each if you agree they're separate concerns.

  Test plan

  - 128 tests pass (uv run pytest tests/)
  - TestSlackApprovalGateway — webhook payload, exception fields, error wrapping, complete_spend approve/deny, request-id lifecycle
  - TestWalletSlackFlow — threshold gating, pending_approval audit, budget commit on approval, correct audit metadata
  - Ruff clean