### PR TITLE
fix(x402): handle nested event loop in execute_x402() via thread dispatch

### DIFF
--- a/src/paygraph/gateways/mock_x402.py
+++ b/src/paygraph/gateways/mock_x402.py
@@ -31,6 +31,20 @@ class MockX402Gateway:
         self.content_type = content_type
         self._receipts: dict[str, X402Receipt] = {}
 
+    async def execute_x402_async(
+        self,
+        url: str,
+        amount_cents: int,
+        vendor: str,
+        memo: str,
+        method: str = "GET",
+        headers: dict | None = None,
+        body: str | None = None,
+    ) -> X402Receipt:
+        return self.execute_x402(
+            url, amount_cents, vendor, memo, method=method, headers=headers, body=body
+        )
+
     def execute_x402(
         self,
         url: str,

--- a/src/paygraph/gateways/x402.py
+++ b/src/paygraph/gateways/x402.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import concurrent.futures
 import json
 from dataclasses import dataclass
 
@@ -84,7 +85,7 @@ class X402Gateway:
             if not evm_private_key:
                 self._payer = str(svm_signer.address)
 
-    async def _execute(
+    async def execute_x402_async(
         self,
         url: str,
         amount_cents: int,
@@ -94,6 +95,28 @@ class X402Gateway:
         headers: dict | None = None,
         body: str | None = None,
     ) -> X402Receipt:
+        """Make a paid HTTP request via the x402 protocol (async).
+
+        Use this coroutine directly from async contexts such as LangGraph
+        agents, FastAPI handlers, or Jupyter notebooks where an event loop
+        is already running. Calling the synchronous :meth:`execute_x402`
+        from those contexts will raise ``RuntimeError``.
+
+        Args:
+            url: The x402-enabled endpoint URL.
+            amount_cents: Payment amount in cents.
+            vendor: Name of the vendor or service.
+            memo: Justification or memo for the payment.
+            method: HTTP method (default ``"GET"``).
+            headers: Optional additional HTTP headers.
+            body: Optional request body string.
+
+        Returns:
+            An ``X402Receipt`` with the response body and transaction details.
+
+        Raises:
+            RuntimeError: If the x402 payment fails (still 402 after retry).
+        """
         from x402.http.clients import x402HttpxClient
 
         async with x402HttpxClient(self._client) as http:
@@ -152,11 +175,15 @@ class X402Gateway:
         headers: dict | None = None,
         body: str | None = None,
     ) -> X402Receipt:
-        """Make a paid HTTP request via the x402 protocol.
+        """Make a paid HTTP request via the x402 protocol (sync).
 
-        Synchronous wrapper around the async x402 client. Sends the
-        request, handles the 402 payment challenge, and returns the
-        final response.
+        Synchronous wrapper around :meth:`execute_x402_async`. Safe to call
+        from any context — including scripts, CLI, and environments with a
+        running event loop (LangGraph agents, FastAPI handlers, Jupyter
+        notebooks). When a loop is already running in the current thread, the
+        call is automatically dispatched to a worker thread with its own fresh
+        event loop. For fully-async callers that prefer to avoid the thread
+        overhead, ``await gateway.execute_x402_async(...)`` is also available.
 
         Args:
             url: The x402-enabled endpoint URL.
@@ -173,6 +200,21 @@ class X402Gateway:
         Raises:
             RuntimeError: If the x402 payment fails (still 402 after retry).
         """
-        return asyncio.run(
-            self._execute(url, amount_cents, vendor, memo, method, headers, body)
+        coro = self.execute_x402_async(
+            url, amount_cents, vendor, memo, method, headers, body
         )
+
+        try:
+            asyncio.get_running_loop()
+            running = True
+        except RuntimeError:
+            running = False
+
+        if running:
+            # A loop is already running in this thread (LangGraph, FastAPI, Jupyter,
+            # etc.). Dispatch to a worker thread so asyncio.run() can create a fresh
+            # event loop there without interfering with the caller's loop.
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return pool.submit(asyncio.run, coro).result()
+
+        return asyncio.run(coro)

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -365,30 +365,16 @@ class AgentWallet:
 
         amount_cents = int(round(amount * 100))
 
-        # Dispatch to the async gateway method if available, otherwise fall back to
-        # the sync variant (MockX402Gateway only implements the sync interface).
-        execute = getattr(self.x402_gateway, "execute_x402_async", None)
         try:
-            if callable(execute):
-                receipt = await execute(
-                    url,
-                    amount_cents,
-                    vendor,
-                    justification,
-                    method=method,
-                    headers=headers,
-                    body=body,
-                )
-            else:
-                receipt = self.x402_gateway.execute_x402(
-                    url,
-                    amount_cents,
-                    vendor,
-                    justification,
-                    method=method,
-                    headers=headers,
-                    body=body,
-                )
+            receipt = await self.x402_gateway.execute_x402_async(
+                url,
+                amount_cents,
+                vendor,
+                justification,
+                method=method,
+                headers=headers,
+                body=body,
+            )
         except SpendDeniedError:
             self._audit.log(
                 AuditRecord.now(
@@ -499,7 +485,7 @@ class AgentWallet:
         wallet = self
 
         @tool("x402_pay", args_schema=X402SpendRequest)
-        async def x402_pay(
+        def x402_pay(
             url: str,
             amount: float,
             vendor: str,
@@ -508,10 +494,26 @@ class AgentWallet:
         ) -> str:
             """Use this tool to pay for an x402-enabled API endpoint. Provide the URL, dollar amount, vendor name, justification, and HTTP method."""
             try:
+                return wallet.request_x402(
+                    url, amount, vendor, justification, method=method
+                )
+            except (PolicyViolationError, SpendDeniedError, GatewayError) as e:
+                return f"x402 payment denied: {e}"
+
+        async def _async_x402_pay(
+            url: str,
+            amount: float,
+            vendor: str,
+            justification: str,
+            method: str = "GET",
+        ) -> str:
+            try:
                 return await wallet.request_x402_async(
                     url, amount, vendor, justification, method=method
                 )
             except (PolicyViolationError, SpendDeniedError, GatewayError) as e:
                 return f"x402 payment denied: {e}"
+
+        x402_pay.coroutine = _async_x402_pay
 
         return x402_pay

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -201,7 +201,12 @@ class AgentWallet:
         headers: dict | None = None,
         body: str | None = None,
     ) -> str:
-        """Make a policy-checked x402 payment to a paid HTTP endpoint.
+        """Make a policy-checked x402 payment to a paid HTTP endpoint (sync).
+
+        Safe to call from non-async code. **Do not call from a running event
+        loop** (LangGraph agents, FastAPI, Jupyter) — use
+        ``await wallet.request_x402_async(...)`` instead, or use
+        ``wallet.x402_tool`` which handles this automatically.
 
         Args:
             url: The x402-enabled API endpoint URL.
@@ -257,6 +262,133 @@ class AgentWallet:
                 headers=headers,
                 body=body,
             )
+        except SpendDeniedError:
+            self._audit.log(
+                AuditRecord.now(
+                    agent_id=self.agent_id,
+                    amount=amount,
+                    vendor=vendor,
+                    justification=justification,
+                    policy_result="denied",
+                    denial_reason="Human denied the x402 payment request",
+                    checks_passed=result.checks_passed,
+                )
+            )
+            raise
+        except Exception as e:
+            self._audit.log(
+                AuditRecord.now(
+                    agent_id=self.agent_id,
+                    amount=amount,
+                    vendor=vendor,
+                    justification=justification,
+                    policy_result="denied",
+                    denial_reason=f"Gateway error: {e}",
+                    checks_passed=result.checks_passed,
+                )
+            )
+            raise GatewayError(str(e)) from e
+
+        self._audit.log(
+            AuditRecord.now(
+                agent_id=self.agent_id,
+                amount=amount,
+                vendor=vendor,
+                justification=justification,
+                policy_result="approved",
+                checks_passed=result.checks_passed,
+                gateway_ref=receipt.gateway_ref,
+                gateway_type=receipt.gateway_type,
+            )
+        )
+
+        return receipt.response_body
+
+    async def request_x402_async(
+        self,
+        url: str,
+        amount: float,
+        vendor: str,
+        justification: str,
+        method: str = "GET",
+        headers: dict | None = None,
+        body: str | None = None,
+    ) -> str:
+        """Make a policy-checked x402 payment to a paid HTTP endpoint (async).
+
+        Use this coroutine from async contexts such as LangGraph agents,
+        FastAPI handlers, or Jupyter notebooks where an event loop is already
+        running. The ``x402_tool`` property uses this method automatically.
+
+        Args:
+            url: The x402-enabled API endpoint URL.
+            amount: Dollar amount for the request (e.g. 0.50 for $0.50).
+            vendor: Name of the service or vendor.
+            justification: Explanation of why this API call is necessary.
+            method: HTTP method (default ``"GET"``).
+            headers: Optional additional HTTP headers.
+            body: Optional request body string.
+
+        Returns:
+            The response body from the paid resource.
+
+        Raises:
+            GatewayError: If no x402 gateway is configured, or the payment fails.
+            PolicyViolationError: If the policy engine denies the request.
+            SpendDeniedError: If a human denies the request (MockX402Gateway).
+        """
+        if self.x402_gateway is None:
+            raise GatewayError(
+                "No x402 gateway configured. Pass x402_gateway to AgentWallet."
+            )
+
+        on_check = (
+            self._audit.start_request(amount, vendor) if self._audit.verbose else None
+        )
+        result = self.policy_engine.evaluate(
+            amount, vendor, justification, on_check=on_check
+        )
+
+        if not result.approved:
+            self._audit.log(
+                AuditRecord.now(
+                    agent_id=self.agent_id,
+                    amount=amount,
+                    vendor=vendor,
+                    justification=justification,
+                    policy_result="denied",
+                    denial_reason=result.denial_reason,
+                    checks_passed=result.checks_passed,
+                )
+            )
+            raise PolicyViolationError(result.denial_reason)
+
+        amount_cents = int(round(amount * 100))
+
+        # Dispatch to the async gateway method if available, otherwise fall back to
+        # the sync variant (MockX402Gateway only implements the sync interface).
+        execute = getattr(self.x402_gateway, "execute_x402_async", None)
+        try:
+            if callable(execute):
+                receipt = await execute(
+                    url,
+                    amount_cents,
+                    vendor,
+                    justification,
+                    method=method,
+                    headers=headers,
+                    body=body,
+                )
+            else:
+                receipt = self.x402_gateway.execute_x402(
+                    url,
+                    amount_cents,
+                    vendor,
+                    justification,
+                    method=method,
+                    headers=headers,
+                    body=body,
+                )
         except SpendDeniedError:
             self._audit.log(
                 AuditRecord.now(
@@ -367,7 +499,7 @@ class AgentWallet:
         wallet = self
 
         @tool("x402_pay", args_schema=X402SpendRequest)
-        def x402_pay(
+        async def x402_pay(
             url: str,
             amount: float,
             vendor: str,
@@ -376,7 +508,7 @@ class AgentWallet:
         ) -> str:
             """Use this tool to pay for an x402-enabled API endpoint. Provide the URL, dollar amount, vendor name, justification, and HTTP method."""
             try:
-                return wallet.request_x402(
+                return await wallet.request_x402_async(
                     url, amount, vendor, justification, method=method
                 )
             except (PolicyViolationError, SpendDeniedError, GatewayError) as e:

--- a/tests/test_x402.py
+++ b/tests/test_x402.py
@@ -10,12 +10,14 @@ from paygraph.gateways.x402 import X402Gateway, X402Receipt
 from paygraph.policy import SpendPolicy
 from paygraph.wallet import AgentWallet
 
-
 # ---------------------------------------------------------------------------
 # Helpers shared by X402Gateway dispatch tests
 # ---------------------------------------------------------------------------
 
-def _fake_receipt(url: str = "https://api.example.com", amount_cents: int = 100) -> X402Receipt:
+
+def _fake_receipt(
+    url: str = "https://api.example.com", amount_cents: int = 100
+) -> X402Receipt:
     return X402Receipt(
         url=url,
         amount_cents=amount_cents,
@@ -207,6 +209,7 @@ class TestRequestX402HttpMethod:
 # X402Gateway sync dispatch tests
 # ---------------------------------------------------------------------------
 
+
 class TestX402GatewaySyncDispatch:
     """execute_x402() must work both with and without a running event loop."""
 
@@ -241,7 +244,9 @@ class TestX402GatewaySyncDispatch:
         gw = _FakeX402Gateway()
 
         async def call_sync_inside_loop() -> X402Receipt:
-            return gw.execute_x402("https://paid-api.example.com", 499, "PaidAPI", "data")
+            return gw.execute_x402(
+                "https://paid-api.example.com", 499, "PaidAPI", "data"
+            )
 
         result = asyncio.run(call_sync_inside_loop())
         assert result.url == "https://paid-api.example.com"

--- a/tests/test_x402.py
+++ b/tests/test_x402.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import tempfile
 
@@ -5,9 +6,43 @@ import pytest
 
 from paygraph.exceptions import GatewayError, PolicyViolationError, SpendDeniedError
 from paygraph.gateways.mock_x402 import MockX402Gateway
-from paygraph.gateways.x402 import X402Receipt
+from paygraph.gateways.x402 import X402Gateway, X402Receipt
 from paygraph.policy import SpendPolicy
 from paygraph.wallet import AgentWallet
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by X402Gateway dispatch tests
+# ---------------------------------------------------------------------------
+
+def _fake_receipt(url: str = "https://api.example.com", amount_cents: int = 100) -> X402Receipt:
+    return X402Receipt(
+        url=url,
+        amount_cents=amount_cents,
+        network="eip155:8453",
+        transaction_hash="0xfakehash",
+        payer="0xFakePayer",
+        gateway_ref="0xfakehash",
+    )
+
+
+class _FakeX402Gateway(X402Gateway):
+    """Minimal X402Gateway that skips SDK imports and returns a fake receipt."""
+
+    def __init__(self) -> None:
+        self._payer = "0xFakePayer"
+
+    async def execute_x402_async(
+        self,
+        url: str,
+        amount_cents: int,
+        vendor: str,
+        memo: str,
+        method: str = "GET",
+        headers: dict | None = None,
+        body: str | None = None,
+    ) -> X402Receipt:
+        return _fake_receipt(url, amount_cents)
 
 
 def _make_wallet(x402_gateway=None, policy=None, **kwargs) -> tuple[AgentWallet, str]:
@@ -166,3 +201,63 @@ class TestRequestX402HttpMethod:
             body='{"name": "test"}',
         )
         assert result == '{"created": true}'
+
+
+# ---------------------------------------------------------------------------
+# X402Gateway sync dispatch tests
+# ---------------------------------------------------------------------------
+
+class TestX402GatewaySyncDispatch:
+    """execute_x402() must work both with and without a running event loop."""
+
+    def test_sync_call_without_running_loop(self):
+        """Standard sync call (scripts, CLI) should return a receipt via asyncio.run()."""
+        gw = _FakeX402Gateway()
+        result = gw.execute_x402("https://api.example.com", 100, "vendor", "memo")
+        assert isinstance(result, X402Receipt)
+        assert result.url == "https://api.example.com"
+        assert result.amount_cents == 100
+        assert result.transaction_hash == "0xfakehash"
+
+    def test_sync_call_from_running_loop_does_not_raise(self):
+        """execute_x402() called from within a running loop must not raise RuntimeError.
+
+        Simulates the LangGraph / FastAPI scenario where an event loop is already
+        running in the current thread when the sync method is invoked.
+        """
+        gw = _FakeX402Gateway()
+
+        async def call_sync_inside_loop() -> X402Receipt:
+            # Deliberately calls the *sync* wrapper from inside a coroutine to
+            # replicate the nested-loop scenario.
+            return gw.execute_x402("https://api.example.com", 200, "vendor", "memo")
+
+        result = asyncio.run(call_sync_inside_loop())
+        assert isinstance(result, X402Receipt)
+        assert result.amount_cents == 200
+
+    def test_sync_call_from_running_loop_returns_correct_receipt(self):
+        """Receipt fields survive the thread-pool round-trip intact."""
+        gw = _FakeX402Gateway()
+
+        async def call_sync_inside_loop() -> X402Receipt:
+            return gw.execute_x402("https://paid-api.example.com", 499, "PaidAPI", "data")
+
+        result = asyncio.run(call_sync_inside_loop())
+        assert result.url == "https://paid-api.example.com"
+        assert result.amount_cents == 499
+        assert result.payer == "0xFakePayer"
+        assert result.gateway_ref == "0xfakehash"
+
+    def test_async_method_available(self):
+        """execute_x402_async() is directly awaitable for fully-async callers."""
+        gw = _FakeX402Gateway()
+
+        async def run():
+            return await gw.execute_x402_async(
+                "https://api.example.com", 50, "vendor", "memo"
+            )
+
+        result = asyncio.run(run())
+        assert isinstance(result, X402Receipt)
+        assert result.amount_cents == 50


### PR DESCRIPTION
Fixes: #15 
Related to this, we should have corresponding async methods for all of the methods in the repo.