### PR TITLE
docs: add CONTRIBUTING.md and ROADMAP.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to PayGraph
+
+Thanks for your interest in contributing to PayGraph! This guide will help you get set up and start contributing.
+
+## Getting started
+
+```bash
+git clone https://github.com/paygraph-ai/paygraph.git
+cd paygraph
+uv pip install -e ".[dev,langgraph,x402]"
+make test
+paygraph demo --live
+```
+
+## Project structure
+
+```
+src/paygraph/
+  wallet.py        # AgentWallet — main orchestrator (spend_tool, x402_tool, crewai_tool)
+  policy.py        # SpendPolicy config + PolicyEngine (stateful daily spend tracking)
+  audit.py         # AuditLogger — structured JSONL audit trail with terminal callbacks
+  exceptions.py    # PayGraphError base → SpendDeniedError, PolicyViolationError, GatewayError
+  cli.py           # `paygraph demo` command (--live, --stripe, --stripe-mpp)
+  gateways/
+    base.py        # BaseGateway abstract class (strategy pattern)
+    mock.py        # MockGateway — fake cards for dev/testing
+    mock_x402.py   # MockX402Gateway — x402 testing without blockchain
+    stripe.py      # StripeCardGateway — virtual cards via Stripe Issuing API
+    stripe_mpp.py  # StripeMPPGateway — scoped Shared Payment Tokens
+    x402.py        # X402Gateway — USDC payments on EVM / Solana
+
+tests/
+  test_policy.py           # Policy engine rules
+  test_wallet.py           # AgentWallet orchestration
+  test_audit.py            # Audit logging
+  test_mock_gateway.py     # Mock gateway behavior
+  test_stripe_gateway.py   # Stripe Issuing integration
+  test_stripe_mpp_gateway.py  # Stripe MPP integration
+  test_x402.py             # x402 protocol
+  test_crewai.py           # CrewAI tool adapter
+```
+
+## Running tests
+
+Run the full suite:
+
+```bash
+make test
+```
+
+Run a single file:
+
+```bash
+uv run pytest tests/test_policy.py -v
+```
+
+Run a single test class or method:
+
+```bash
+uv run pytest tests/test_policy.py::TestAmountCap::test_under_limit -v
+```
+
+CI runs against Python 3.10–3.13.
+
+**Test conventions:**
+- Class-based test organization (e.g. `TestAmountCap`, `TestDailyBudget`)
+- `_make_wallet()` helper creates a temp audit file and returns a configured wallet
+- `_read_audit()` reads back audit records from the temp file
+- Use `unittest.mock.patch` for date/time mocking — no conftest or shared fixtures
+
+## Code style
+
+```bash
+make format   # auto-format with ruff (style + import sorting)
+make lint     # lint with ruff
+make check    # CI entrypoint (lint + test)
+```
+
+- **Ruff** rules: E, F, I (E501 ignored). Line length 88.
+- **Google-style docstrings** (used by mkdocstrings for the docs site)
+- **Type hints** throughout — Python 3.10+
+- **Dataclasses** for data structures, **Pydantic** for validation
+
+## Submitting a PR
+
+1. Branch from `main`
+2. Write tests for new behavior
+3. Run `make check` and fix any failures
+4. Open a PR with a clear description of what changed and why
+5. If adding a new gateway, include a mock variant for testing
+
+## What to work on
+
+Check the [ROADMAP.md](ROADMAP.md) for planned features at every level of complexity. Issues tagged [`good first issue`](https://github.com/paygraph-ai/paygraph/labels/good%20first%20issue) are a great starting point.
+
+## Communication
+
+- **GitHub Issues** — bug reports, feature requests, and discussion
+- **Discord** — [join the community](https://discord.gg/PPVZWSMdEm)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,53 @@
+# Roadmap
+
+This is the contributor-facing roadmap for PayGraph. Items are grouped by how close they are to landing. Everything here is open for contribution — see the bottom of this file for how to get involved.
+
+## Shipping now (2–4 weeks)
+
+These are actively being worked on or are ready to pick up.
+
+### MCP server
+Add `paygraph/mcp_server.py` exposing spend and x402 tools as an MCP server. New installable extra: `paygraph[mcp]`.
+
+### HITL Slack webhook
+Async human-in-the-loop approval channel that replaces the terminal `input()` prompt in MockGateway. Lets teams approve spend requests from Slack instead of a local terminal.
+
+### Cross-gateway budget tracker
+Unified daily budget tracking across card and x402 gateways. Requires shared budget state between `policy.py` and `wallet.py` so a single `SpendPolicy` governs total agent spend regardless of payment rail.
+
+### Better StripeCardGateway error handling
+Map Stripe API errors to specific PayGraph exception types (e.g. card declined, insufficient funds, rate limited) instead of generic `GatewayError`.
+
+### Additional payment integrations
+Ramp integration first, then Lithic / Marqeta / Brex following the same `BaseGateway` pattern. Each new gateway needs a corresponding mock variant for testing.
+
+## Exploring (1–3 months)
+
+Design is in progress or needs more input before implementation starts.
+
+### KYC/AML gate
+Pre-payment compliance hook that runs before the gateway executes. Could be a new policy check or a standalone middleware step.
+
+### Async gateway variants
+`AsyncAgentWallet` and `BaseAsyncGateway` for non-blocking payment flows. Important for high-throughput agent systems.
+
+### More framework integrations
+Adapters for Vercel AI SDK, AutoGen, Pydantic AI, and Semantic Kernel — similar to the existing LangGraph and CrewAI integrations.
+
+## Ideas welcomed (longer horizon)
+
+These are directions we think are interesting but don't have concrete designs for yet. If any of these excite you, open an issue to start the conversation.
+
+- **A2A / SEPA / RTP rails** — non-card, non-crypto payment networks
+- **Agent-to-agent payment flows** — agents paying other agents with policy enforcement on both sides
+- **Native MCP tool registry** — auto-register PayGraph tools in MCP-compatible agent runtimes
+
+## How to contribute to roadmap items
+
+**Shipping now** — These are ready to build. Comment on the relevant issue (or open one) to claim it, then submit a PR. Check [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
+
+**Exploring** — Start by opening an issue with your proposed design. We'll discuss the approach before any code is written.
+
+**Ideas welcomed** — Open an issue describing the use case and how you'd approach it. The more concrete the proposal, the faster it moves up the roadmap.
+
+Questions? Reach out on [Discord](https://discord.gg/PPVZWSMdEm) or open a [GitHub Issue](https://github.com/paygraph-ai/paygraph/issues).


### PR DESCRIPTION
## Summary
- Add **CONTRIBUTING.md** with getting started, project structure, testing, code style, and PR 
  workflow
- Add **ROADMAP.md** with three-tier feature roadmap (shipping now, exploring, ideas welcomed)
- Unblocks community contributions by giving newcomers a clear path to get involved

## Test plan
- [x] All file paths and commands in CONTRIBUTING.md match the actual codebase
- [x] Links to Discord, GitHub Issues, and `good first issue` label are correct
- [x] Both files read cleanly top-to-bottom for a first-time contributor