### PR TITLE
fix: reject negative and zero spend amounts in PolicyEngine

### DIFF
--- a/src/paygraph/policy.py
+++ b/src/paygraph/policy.py
@@ -107,6 +107,14 @@ class PolicyEngine:
                 checks_passed=checks_passed,
             )
 
+        # 0. Positive amount check
+        if amount <= 0:
+            return _fail(
+                "positive_amount",
+                f"Amount must be positive (got ${amount:.2f})",
+            )
+        _pass("positive_amount")
+
         # 1. Amount cap
         if amount > self.policy.max_transaction:
             return _fail(

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -24,13 +24,41 @@ class TestAmountCap:
         assert "$50.01" in result.denial_reason
         assert "$50.00" in result.denial_reason
 
-    def test_amount_cap_is_first_check(self):
+    def test_amount_cap_is_second_check(self):
         engine = PolicyEngine(
             SpendPolicy(max_transaction=10.0, blocked_vendors=["vendor"])
         )
         result = engine.evaluate(100.0, "vendor", "reason")
         assert not result.approved
         assert "exceeds limit" in result.denial_reason
+        assert result.checks_passed == ["positive_amount"]
+
+
+class TestPositiveAmount:
+    def test_positive_amount_passes(self):
+        engine = PolicyEngine(SpendPolicy())
+        result = engine.evaluate(5.0, "vendor", "reason")
+        assert result.approved
+        assert "positive_amount" in result.checks_passed
+
+    def test_zero_amount_denied(self):
+        engine = PolicyEngine(SpendPolicy())
+        result = engine.evaluate(0.0, "vendor", "reason")
+        assert not result.approved
+        assert "must be positive" in result.denial_reason
+        assert result.checks_passed == []
+
+    def test_negative_amount_denied(self):
+        engine = PolicyEngine(SpendPolicy())
+        result = engine.evaluate(-10.0, "vendor", "reason")
+        assert not result.approved
+        assert "must be positive" in result.denial_reason
+
+    def test_positive_amount_is_first_check(self):
+        # Even if amount exceeds cap, positive check runs first
+        engine = PolicyEngine(SpendPolicy(max_transaction=5.0))
+        result = engine.evaluate(-10.0, "vendor", "reason")
+        assert "must be positive" in result.denial_reason
         assert result.checks_passed == []
 
 
@@ -161,6 +189,7 @@ class TestCheckOrdering:
         result = engine.evaluate(5.0, "vendor", "reason")
         assert result.approved
         assert result.checks_passed == [
+            "positive_amount",
             "amount_cap",
             "vendor_allowlist",
             "vendor_blocklist",
@@ -174,6 +203,6 @@ class TestCheckOrdering:
             SpendPolicy(max_transaction=1.0, blocked_vendors=["vendor"])
         )
         result = engine.evaluate(10.0, "vendor", "reason")
-        # Amount cap fails first, so blocked vendor check never runs
+        # Amount cap fails second (after positive_amount), so blocked vendor check never runs
         assert "exceeds limit" in result.denial_reason
-        assert result.checks_passed == []
+        assert result.checks_passed == ["positive_amount"]


### PR DESCRIPTION
Previously, PolicyEngine.evaluate() only checked if amount > max_transaction but never validated that the amount was positive. This allowed invalid spend requests with negative or zero amounts to pass all policy checks.

Added a new `positive_amount` check as the first check in the evaluation chain that rejects amounts <= 0 with a clear error message.