### PR TITLE
feat: unified gateway architecture (v0.2)

### DIFF
--- a/src/paygraph/__init__.py
+++ b/src/paygraph/__init__.py
@@ -5,7 +5,13 @@ from paygraph.exceptions import (
     PolicyViolationError,
     SpendDeniedError,
 )
-from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.base import (
+    BaseGateway,
+    CardResult,
+    SpendResult,
+    VirtualCard,
+    X402Result,
+)
 from paygraph.gateways.mock import MockGateway
 from paygraph.gateways.mock_x402 import MockX402Gateway
 from paygraph.gateways.slack import SlackApprovalGateway
@@ -19,13 +25,16 @@ __all__ = [
     "AgentWallet",
     "SpendPolicy",
     "BaseGateway",
+    "SpendResult",
+    "CardResult",
+    "X402Result",
     "VirtualCard",
+    "X402Receipt",
     "StripeCardGateway",
     "StripeMPPGateway",
     "MockGateway",
     "SlackApprovalGateway",
     "X402Gateway",
-    "X402Receipt",
     "MockX402Gateway",
     "PayGraphError",
     "SpendDeniedError",

--- a/src/paygraph/cli.py
+++ b/src/paygraph/cli.py
@@ -25,7 +25,7 @@ def run_demo() -> None:
     )
 
     wallet = AgentWallet(
-        gateway=MockGateway(auto_approve=True),
+        gateways=MockGateway(auto_approve=True),
         policy=policy,
         agent_id="demo-agent",
         log_path=audit_path,
@@ -239,7 +239,7 @@ def run_live_demo(model: str, stripe: bool = False, stripe_mpp: bool = False) ->
     )
 
     wallet = AgentWallet(
-        gateway=gateway,
+        gateways=gateway,
         policy=policy,
         agent_id="live-demo-agent",
         log_path=audit_path,

--- a/src/paygraph/exceptions.py
+++ b/src/paygraph/exceptions.py
@@ -21,12 +21,21 @@ class HumanApprovalRequired(PayGraphError):
         request_id: Unique ID for this pending approval (use to resume).
         amount: Dollar amount awaiting approval.
         vendor: Vendor name awaiting approval.
+        gateway_name: Name of the gateway that initiated the approval.
+            Pass this back to ``complete_spend()`` to resolve the correct gateway.
     """
 
-    def __init__(self, request_id: str, amount: float, vendor: str) -> None:
+    def __init__(
+        self,
+        request_id: str,
+        amount: float,
+        vendor: str,
+        gateway_name: str = "default",
+    ) -> None:
         self.request_id = request_id
         self.amount = amount
         self.vendor = vendor
+        self.gateway_name = gateway_name
         super().__init__(
             f"Spend of ${amount:.2f} for '{vendor}' requires human approval "
             f"(request_id={request_id})"

--- a/src/paygraph/gateways/__init__.py
+++ b/src/paygraph/gateways/__init__.py
@@ -1,4 +1,10 @@
-from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.base import (
+    BaseGateway,
+    CardResult,
+    SpendResult,
+    VirtualCard,
+    X402Result,
+)
 from paygraph.gateways.mock import MockGateway
 from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.gateways.stripe import StripeCardGateway
@@ -6,6 +12,9 @@ from paygraph.gateways.stripe_mpp import StripeMPPGateway
 
 __all__ = [
     "BaseGateway",
+    "SpendResult",
+    "CardResult",
+    "X402Result",
     "VirtualCard",
     "StripeCardGateway",
     "StripeMPPGateway",

--- a/src/paygraph/gateways/base.py
+++ b/src/paygraph/gateways/base.py
@@ -1,72 +1,145 @@
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 
 @dataclass
-class VirtualCard:
-    """A virtual card returned by a card gateway.
+class SpendResult:
+    """Base result returned by any gateway after a successful spend.
+
+    Attributes:
+        amount_cents: Amount spent in cents.
+        gateway_ref: Unique reference ID from the gateway.
+        gateway_type: Gateway identifier (e.g. ``"mock"``, ``"stripe_test"``, ``"x402"``).
+    """
+
+    amount_cents: int
+    gateway_ref: str
+    gateway_type: str
+
+
+@dataclass
+class CardResult(SpendResult):
+    """Result of a successful card spend (virtual card details).
 
     Attributes:
         pan: Primary Account Number (full card number). **Treat as sensitive.**
         cvv: Card Verification Value.
         expiry: Expiration date in ``MM/YY`` format.
         spend_limit_cents: Maximum spend limit in cents.
-        gateway_ref: Unique reference ID from the gateway.
-        gateway_type: Gateway identifier (e.g. ``"mock"``, ``"stripe_test"``).
     """
 
-    pan: str
-    cvv: str
-    expiry: str
-    spend_limit_cents: int
-    gateway_ref: str
-    gateway_type: str
+    pan: str = ""
+    cvv: str = ""
+    expiry: str = ""
+    spend_limit_cents: int = 0
 
-    def redacted(self) -> "VirtualCard":
+    def redacted(self) -> "CardResult":
         """Return a copy with the PAN masked, showing only the last 4 digits.
 
         Returns:
-            A new ``VirtualCard`` with ``pan`` set to ``****XXXX``.
+            A new ``CardResult`` with ``pan`` set to ``****XXXX``.
         """
-        return VirtualCard(
+        return CardResult(
             pan=f"****{self.pan[-4:]}",
             cvv=self.cvv,
             expiry=self.expiry,
             spend_limit_cents=self.spend_limit_cents,
+            amount_cents=self.amount_cents,
             gateway_ref=self.gateway_ref,
             gateway_type=self.gateway_type,
         )
 
 
-class BaseGateway(ABC):
-    """Abstract base class for card payment gateways.
+@dataclass
+class X402Result(SpendResult):
+    """Result of a successful x402 payment.
 
-    Subclass this to implement a custom card gateway. You must implement
-    ``execute_spend()`` and ``revoke()``.
+    Attributes:
+        url: The x402-enabled endpoint URL that was called.
+        network: Blockchain network identifier (e.g. ``"eip155:8453"``).
+        transaction_hash: On-chain transaction hash.
+        payer: Wallet address of the payer.
+        status_code: HTTP status code of the response.
+        response_body: Body of the HTTP response from the paid endpoint.
+        content_type: Content-Type header of the response.
+    """
+
+    url: str = ""
+    network: str = ""
+    transaction_hash: str = ""
+    payer: str = ""
+    status_code: int = 200
+    response_body: str = ""
+    content_type: str = "application/json"
+
+
+# Deprecated aliases — kept for one release cycle
+VirtualCard = CardResult
+
+
+class BaseGateway(ABC):
+    """Abstract base class for all payment gateways.
+
+    Subclass this to implement a custom gateway. You must implement
+    ``execute()``. Override ``execute_async()`` for native async support
+    and ``revoke()`` for card-style gateways that support cancellation.
     """
 
     @abstractmethod
-    def execute_spend(self, amount_cents: int, vendor: str, memo: str) -> VirtualCard:
-        """Create a virtual card for the given spend.
+    def execute(
+        self, amount_cents: int, vendor: str, memo: str, **kwargs
+    ) -> SpendResult:
+        """Execute a spend for the given amount.
 
         Args:
-            amount_cents: Spend limit in cents.
+            amount_cents: Spend amount in cents.
             vendor: Name of the vendor.
             memo: Justification or memo for the spend.
+            **kwargs: Gateway-specific parameters (e.g. ``url``, ``method``
+                for x402 gateways).
 
         Returns:
-            A ``VirtualCard`` with the card details.
+            A ``SpendResult`` (or subclass) with the transaction details.
         """
         ...
 
-    @abstractmethod
-    def revoke(self, gateway_ref: str) -> bool:
-        """Revoke (cancel) a previously issued virtual card.
+    async def execute_async(
+        self, amount_cents: int, vendor: str, memo: str, **kwargs
+    ) -> SpendResult:
+        """Execute a spend asynchronously.
+
+        Default implementation runs ``execute()`` in a thread pool.
+        Override for native async support (e.g. x402 gateways).
 
         Args:
-            gateway_ref: The ``gateway_ref`` from the ``VirtualCard``.
+            amount_cents: Spend amount in cents.
+            vendor: Name of the vendor.
+            memo: Justification or memo for the spend.
+            **kwargs: Gateway-specific parameters.
 
         Returns:
-            True if the card was successfully revoked, False if not found.
+            A ``SpendResult`` (or subclass) with the transaction details.
         """
-        ...
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self.execute(amount_cents, vendor, memo, **kwargs)
+        )
+
+    def revoke(self, gateway_ref: str) -> bool:
+        """Revoke (cancel) a previously issued spend.
+
+        Optional — card gateways override this, x402 gateways typically don't.
+
+        Args:
+            gateway_ref: The ``gateway_ref`` from the ``SpendResult``.
+
+        Returns:
+            True if successfully revoked, False if not found.
+
+        Raises:
+            NotImplementedError: If this gateway does not support revocation.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support revoke"
+        )

--- a/src/paygraph/gateways/base.py
+++ b/src/paygraph/gateways/base.py
@@ -92,12 +92,14 @@ class BaseGateway(ABC):
     ) -> SpendResult:
         """Execute a spend for the given amount.
 
+        Subclasses should declare gateway-specific parameters as explicit
+        keyword-only arguments rather than consuming ``**kwargs``. This
+        ensures callers get immediate feedback on typos.
+
         Args:
             amount_cents: Spend amount in cents.
             vendor: Name of the vendor.
             memo: Justification or memo for the spend.
-            **kwargs: Gateway-specific parameters (e.g. ``url``, ``method``
-                for x402 gateways).
 
         Returns:
             A ``SpendResult`` (or subclass) with the transaction details.
@@ -116,7 +118,6 @@ class BaseGateway(ABC):
             amount_cents: Spend amount in cents.
             vendor: Name of the vendor.
             memo: Justification or memo for the spend.
-            **kwargs: Gateway-specific parameters.
 
         Returns:
             A ``SpendResult`` (or subclass) with the transaction details.

--- a/src/paygraph/gateways/mock.py
+++ b/src/paygraph/gateways/mock.py
@@ -1,7 +1,7 @@
 import secrets
 
 from paygraph.exceptions import SpendDeniedError
-from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.base import BaseGateway, CardResult
 
 
 class MockGateway(BaseGateway):
@@ -19,9 +19,9 @@ class MockGateway(BaseGateway):
                 approve all requests automatically.
         """
         self.auto_approve = auto_approve
-        self._cards: dict[str, VirtualCard] = {}
+        self._cards: dict[str, CardResult] = {}
 
-    def execute_spend(self, amount_cents: int, vendor: str, memo: str) -> VirtualCard:
+    def execute(self, amount_cents: int, vendor: str, memo: str, **kwargs) -> CardResult:
         """Create a mock virtual card, optionally prompting for approval.
 
         Args:
@@ -30,7 +30,7 @@ class MockGateway(BaseGateway):
             memo: Justification for the spend.
 
         Returns:
-            A ``VirtualCard`` with a fake PAN (``4111111111111111``).
+            A ``CardResult`` with a fake PAN (``4111111111111111``).
 
         Raises:
             SpendDeniedError: If the human denies the approval prompt.
@@ -46,11 +46,12 @@ class MockGateway(BaseGateway):
                 )
 
         token = f"mock_{secrets.token_hex(8)}"
-        card = VirtualCard(
+        card = CardResult(
             pan="4111111111111111",
             cvv="123",
             expiry="12/28",
             spend_limit_cents=amount_cents,
+            amount_cents=amount_cents,
             gateway_ref=token,
             gateway_type="mock",
         )

--- a/src/paygraph/gateways/mock.py
+++ b/src/paygraph/gateways/mock.py
@@ -21,7 +21,7 @@ class MockGateway(BaseGateway):
         self.auto_approve = auto_approve
         self._cards: dict[str, CardResult] = {}
 
-    def execute(self, amount_cents: int, vendor: str, memo: str, **kwargs) -> CardResult:
+    def execute(self, amount_cents: int, vendor: str, memo: str) -> CardResult:
         """Create a mock virtual card, optionally prompting for approval.
 
         Args:

--- a/src/paygraph/gateways/mock_x402.py
+++ b/src/paygraph/gateways/mock_x402.py
@@ -39,17 +39,27 @@ class MockX402Gateway(BaseGateway):
         amount_cents: int,
         vendor: str,
         memo: str,
-        **kwargs,
+        *,
+        url: str = "",
+        method: str = "GET",
+        headers: dict | None = None,
+        body: str | None = None,
     ) -> X402Result:
         """Async variant — delegates to :meth:`execute`."""
-        return self.execute(amount_cents, vendor, memo, **kwargs)
+        return self.execute(
+            amount_cents, vendor, memo, url=url, method=method, headers=headers, body=body
+        )
 
     def execute(
         self,
         amount_cents: int,
         vendor: str,
         memo: str,
-        **kwargs,
+        *,
+        url: str = "",
+        method: str = "GET",
+        headers: dict | None = None,
+        body: str | None = None,
     ) -> X402Result:
         """Simulate an x402 payment, optionally prompting for approval.
 
@@ -57,8 +67,10 @@ class MockX402Gateway(BaseGateway):
             amount_cents: Payment amount in cents.
             vendor: Name of the vendor.
             memo: Justification for the payment.
-            **kwargs: Expected to contain ``url``. Optional: ``method``,
-                ``headers``, ``body`` (ignored in mock).
+            url: The x402-enabled endpoint URL.
+            method: HTTP method (ignored in mock).
+            headers: Optional HTTP headers (ignored in mock).
+            body: Optional request body (ignored in mock).
 
         Returns:
             An ``X402Result`` with a fake transaction hash and the
@@ -67,7 +79,6 @@ class MockX402Gateway(BaseGateway):
         Raises:
             SpendDeniedError: If the human denies the approval prompt.
         """
-        url = kwargs.get("url", "")
         amount_dollars = amount_cents / 100
         if not self.auto_approve:
             response = input(

--- a/src/paygraph/gateways/mock_x402.py
+++ b/src/paygraph/gateways/mock_x402.py
@@ -1,10 +1,13 @@
 import secrets
 
 from paygraph.exceptions import SpendDeniedError
-from paygraph.gateways.x402 import X402Receipt
+from paygraph.gateways.base import BaseGateway, X402Result
+
+# Deprecated alias — kept for one release cycle
+X402Receipt = X402Result
 
 
-class MockX402Gateway:
+class MockX402Gateway(BaseGateway):
     """Mock x402 gateway for testing without blockchain access.
 
     Simulates the x402 payment flow by generating fake transaction hashes
@@ -29,50 +32,42 @@ class MockX402Gateway:
         self.response_body = response_body
         self.status_code = status_code
         self.content_type = content_type
-        self._receipts: dict[str, X402Receipt] = {}
+        self._receipts: dict[str, X402Result] = {}
 
-    async def execute_x402_async(
+    async def execute_async(
         self,
-        url: str,
         amount_cents: int,
         vendor: str,
         memo: str,
-        method: str = "GET",
-        headers: dict | None = None,
-        body: str | None = None,
-    ) -> X402Receipt:
-        return self.execute_x402(
-            url, amount_cents, vendor, memo, method=method, headers=headers, body=body
-        )
+        **kwargs,
+    ) -> X402Result:
+        """Async variant — delegates to :meth:`execute`."""
+        return self.execute(amount_cents, vendor, memo, **kwargs)
 
-    def execute_x402(
+    def execute(
         self,
-        url: str,
         amount_cents: int,
         vendor: str,
         memo: str,
-        method: str = "GET",
-        headers: dict | None = None,
-        body: str | None = None,
-    ) -> X402Receipt:
+        **kwargs,
+    ) -> X402Result:
         """Simulate an x402 payment, optionally prompting for approval.
 
         Args:
-            url: The endpoint URL.
             amount_cents: Payment amount in cents.
             vendor: Name of the vendor.
             memo: Justification for the payment.
-            method: HTTP method (ignored in mock).
-            headers: Optional headers (ignored in mock).
-            body: Optional body (ignored in mock).
+            **kwargs: Expected to contain ``url``. Optional: ``method``,
+                ``headers``, ``body`` (ignored in mock).
 
         Returns:
-            An ``X402Receipt`` with a fake transaction hash and the
+            An ``X402Result`` with a fake transaction hash and the
             configured response body.
 
         Raises:
             SpendDeniedError: If the human denies the approval prompt.
         """
+        url = kwargs.get("url", "")
         amount_dollars = amount_cents / 100
         if not self.auto_approve:
             response = input(
@@ -84,13 +79,14 @@ class MockX402Gateway:
                 )
 
         tx_hash = f"0xmock_{secrets.token_hex(16)}"
-        receipt = X402Receipt(
+        receipt = X402Result(
             url=url,
             amount_cents=amount_cents,
             network="eip155:8453",
             transaction_hash=tx_hash,
             payer="0xMockPayer1234567890abcdef",
             gateway_ref=tx_hash,
+            gateway_type="x402",
             status_code=self.status_code,
             response_body=self.response_body,
             content_type=self.content_type,

--- a/src/paygraph/gateways/slack.py
+++ b/src/paygraph/gateways/slack.py
@@ -3,7 +3,7 @@ import secrets
 import httpx
 
 from paygraph.exceptions import GatewayError, HumanApprovalRequired, SpendDeniedError
-from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.base import BaseGateway, CardResult, SpendResult
 
 
 class SlackApprovalGateway(BaseGateway):
@@ -26,7 +26,7 @@ class SlackApprovalGateway(BaseGateway):
             inner_gateway=MockGateway(auto_approve=True),
         )
         wallet = AgentWallet(
-            gateway=gateway,
+            gateways=gateway,
             policy=SpendPolicy(require_human_approval_above=20.0),
         )
 
@@ -98,7 +98,9 @@ class SlackApprovalGateway(BaseGateway):
         }
         raise HumanApprovalRequired(request_id, amount_dollars, vendor)
 
-    def execute_spend(self, amount_cents: int, vendor: str, memo: str) -> VirtualCard:
+    def execute(
+        self, amount_cents: int, vendor: str, memo: str, **kwargs
+    ) -> SpendResult:
         """Execute a spend directly via the inner gateway (below-threshold path).
 
         Args:
@@ -107,11 +109,11 @@ class SlackApprovalGateway(BaseGateway):
             memo: Justification for the spend.
 
         Returns:
-            A ``VirtualCard`` from the inner gateway.
+            A ``SpendResult`` from the inner gateway.
         """
-        return self.inner_gateway.execute_spend(amount_cents, vendor, memo)
+        return self.inner_gateway.execute(amount_cents, vendor, memo, **kwargs)
 
-    def complete_spend(self, request_id: str, approved: bool) -> VirtualCard:
+    def complete_spend(self, request_id: str, approved: bool) -> CardResult:
         """Resume a pending spend after a human has responded in Slack.
 
         Args:
@@ -120,7 +122,7 @@ class SlackApprovalGateway(BaseGateway):
             approved: ``True`` if the human approved, ``False`` if denied.
 
         Returns:
-            A ``VirtualCard`` from the inner gateway if approved.
+            A ``CardResult`` from the inner gateway if approved.
 
         Raises:
             SpendDeniedError: If ``approved`` is ``False``.
@@ -132,7 +134,7 @@ class SlackApprovalGateway(BaseGateway):
                 f"Human denied spend of ${pending['amount_cents'] / 100:.2f} "
                 f"for {pending['vendor']}"
             )
-        return self.inner_gateway.execute_spend(
+        return self.inner_gateway.execute(
             pending["amount_cents"], pending["vendor"], pending["memo"]
         )
 

--- a/src/paygraph/gateways/slack.py
+++ b/src/paygraph/gateways/slack.py
@@ -33,8 +33,10 @@ class SlackApprovalGateway(BaseGateway):
         try:
             wallet.request_spend(50.0, "Anthropic", "need tokens")
         except HumanApprovalRequired as e:
-            # Store e.request_id — resume later when human responds
-            result = wallet.complete_spend(e.request_id, approved=True)
+            # Store e.request_id and e.gateway_name — resume later when human responds
+            result = wallet.complete_spend(
+                e.request_id, approved=True, gateway=e.gateway_name
+            )
     """
 
     def __init__(self, webhook_url: str, inner_gateway: BaseGateway) -> None:

--- a/src/paygraph/gateways/stripe.py
+++ b/src/paygraph/gateways/stripe.py
@@ -1,7 +1,7 @@
 import httpx
 
 from paygraph.exceptions import GatewayError
-from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.base import BaseGateway, CardResult
 
 _DEFAULT_BILLING = {
     "line1": "1 Market St",
@@ -184,7 +184,7 @@ class StripeCardGateway(BaseGateway):
         except httpx.HTTPError as e:
             raise GatewayError(f"Stripe API unreachable: {e}") from e
 
-    def execute_spend(self, amount_cents: int, vendor: str, memo: str) -> VirtualCard:
+    def execute(self, amount_cents: int, vendor: str, memo: str, **kwargs) -> CardResult:
         """Create a Stripe Issuing virtual card with the given spend limit.
 
         Calls the Stripe ``/v1/issuing/cards`` API to mint a new card
@@ -196,7 +196,7 @@ class StripeCardGateway(BaseGateway):
             memo: Justification (stored in card metadata, truncated to 500 chars).
 
         Returns:
-            A ``VirtualCard`` with the real PAN, CVV, and expiry.
+            A ``CardResult`` with the real PAN, CVV, and expiry.
 
         Raises:
             GatewayError: If the Stripe API call fails.
@@ -214,11 +214,12 @@ class StripeCardGateway(BaseGateway):
         exp_month = detail["exp_month"]
         exp_year = detail["exp_year"]
 
-        return VirtualCard(
+        return CardResult(
             pan=detail["number"],
             cvv=detail["cvc"],
             expiry=f"{exp_month:02d}/{exp_year % 100:02d}",
             spend_limit_cents=amount_cents,
+            amount_cents=amount_cents,
             gateway_ref=detail["id"],
             gateway_type=self._gateway_type,
         )

--- a/src/paygraph/gateways/stripe.py
+++ b/src/paygraph/gateways/stripe.py
@@ -184,7 +184,7 @@ class StripeCardGateway(BaseGateway):
         except httpx.HTTPError as e:
             raise GatewayError(f"Stripe API unreachable: {e}") from e
 
-    def execute(self, amount_cents: int, vendor: str, memo: str, **kwargs) -> CardResult:
+    def execute(self, amount_cents: int, vendor: str, memo: str) -> CardResult:
         """Create a Stripe Issuing virtual card with the given spend limit.
 
         Calls the Stripe ``/v1/issuing/cards`` API to mint a new card

--- a/src/paygraph/gateways/stripe_mpp.py
+++ b/src/paygraph/gateways/stripe_mpp.py
@@ -8,7 +8,7 @@ Requires Stripe **machine payments / agentic commerce** access and API version
 ``2026-03-04.preview``. See https://docs.stripe.com/payments/machine/mpp and
 https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens
 
-``VirtualCard`` is used for API compatibility only: SPTs have no PAN/CVV.
+``CardResult`` is used for API compatibility only: SPTs have no PAN/CVV.
 Integrators should use ``gateway_ref`` (the ``spt_...`` id) when talking to
 merchants, not the sentinel ``pan``/``cvv``/``expiry`` fields.
 """
@@ -20,7 +20,7 @@ import time
 import httpx
 
 from paygraph.exceptions import GatewayError
-from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.base import BaseGateway, CardResult
 
 # Preview REST paths — confirm against Stripe preview API reference if calls fail.
 _ISSUE_PATH = "/v1/shared_payment/issued_tokens"
@@ -106,7 +106,7 @@ class StripeMPPGateway(BaseGateway):
         self._currency = currency.lower()
         self._expires_in_seconds = expires_in_seconds
 
-    def execute_spend(self, amount_cents: int, vendor: str, memo: str) -> VirtualCard:
+    def execute(self, amount_cents: int, vendor: str, memo: str, **kwargs) -> CardResult:
         """Issue an SPT with usage limits matching this spend request.
 
         Metadata truncation matches ``StripeCardGateway`` (vendor 100 chars, memo 500).
@@ -140,11 +140,12 @@ class StripeMPPGateway(BaseGateway):
                 "Stripe API returned no token id for shared payment issuance"
             )
 
-        return VirtualCard(
+        return CardResult(
             pan=self._SPT_PAN,
             cvv=self._SPT_CVV,
             expiry=self._SPT_EXPIRY,
             spend_limit_cents=amount_cents,
+            amount_cents=amount_cents,
             gateway_ref=token_id,
             gateway_type=self._gateway_type,
         )

--- a/src/paygraph/gateways/stripe_mpp.py
+++ b/src/paygraph/gateways/stripe_mpp.py
@@ -106,7 +106,7 @@ class StripeMPPGateway(BaseGateway):
         self._currency = currency.lower()
         self._expires_in_seconds = expires_in_seconds
 
-    def execute(self, amount_cents: int, vendor: str, memo: str, **kwargs) -> CardResult:
+    def execute(self, amount_cents: int, vendor: str, memo: str) -> CardResult:
         """Issue an SPT with usage limits matching this spend request.
 
         Metadata truncation matches ``StripeCardGateway`` (vendor 100 chars, memo 500).

--- a/src/paygraph/gateways/x402.py
+++ b/src/paygraph/gateways/x402.py
@@ -2,40 +2,14 @@ import asyncio
 import base64
 import concurrent.futures
 import json
-from dataclasses import dataclass
+
+from paygraph.gateways.base import BaseGateway, X402Result
+
+# Deprecated alias — kept for one release cycle
+X402Receipt = X402Result
 
 
-@dataclass
-class X402Receipt:
-    """Result of a successful x402 payment.
-
-    Attributes:
-        url: The x402-enabled endpoint URL that was called.
-        amount_cents: Amount paid in cents.
-        network: Blockchain network identifier (e.g. ``"eip155:8453"``).
-        transaction_hash: On-chain transaction hash.
-        payer: Wallet address of the payer.
-        gateway_ref: Unique reference (usually the transaction hash).
-        gateway_type: Always ``"x402"``.
-        status_code: HTTP status code of the response.
-        response_body: Body of the HTTP response from the paid endpoint.
-        content_type: Content-Type header of the response.
-    """
-
-    url: str
-    amount_cents: int
-    network: str
-    transaction_hash: str
-    payer: str
-    gateway_ref: str
-    gateway_type: str = "x402"
-
-    status_code: int = 200
-    response_body: str = ""
-    content_type: str = "application/json"
-
-
-class X402Gateway:
+class X402Gateway(BaseGateway):
     """Gateway for x402 HTTP 402 payments using on-chain USDC.
 
     Supports EVM chains (Base, Ethereum, etc.) and Solana. At least one
@@ -85,48 +59,48 @@ class X402Gateway:
             if not evm_private_key:
                 self._payer = str(svm_signer.address)
 
-    async def execute_x402_async(
+    async def execute_async(
         self,
-        url: str,
         amount_cents: int,
         vendor: str,
         memo: str,
-        method: str = "GET",
-        headers: dict | None = None,
-        body: str | None = None,
-    ) -> X402Receipt:
+        **kwargs,
+    ) -> X402Result:
         """Make a paid HTTP request via the x402 protocol (async).
 
         Use this coroutine directly from async contexts such as LangGraph
         agents, FastAPI handlers, or Jupyter notebooks where an event loop
-        is already running. Calling the synchronous :meth:`execute_x402`
+        is already running. Calling the synchronous :meth:`execute`
         from those contexts will raise ``RuntimeError``.
 
         Args:
-            url: The x402-enabled endpoint URL.
             amount_cents: Payment amount in cents.
             vendor: Name of the vendor or service.
             memo: Justification or memo for the payment.
-            method: HTTP method (default ``"GET"``).
-            headers: Optional additional HTTP headers.
-            body: Optional request body string.
+            **kwargs: Must include ``url``. Optional: ``method`` (default ``"GET"``),
+                ``headers``, ``body``.
 
         Returns:
-            An ``X402Receipt`` with the response body and transaction details.
+            An ``X402Result`` with the response body and transaction details.
 
         Raises:
             RuntimeError: If the x402 payment fails (still 402 after retry).
         """
+        url = kwargs.get("url", "")
+        method = kwargs.get("method", "GET")
+        headers = kwargs.get("headers")
+        body = kwargs.get("body")
+
         from x402.http.clients import x402HttpxClient
 
         async with x402HttpxClient(self._client) as http:
-            kwargs: dict = {}
+            req_kwargs: dict = {}
             if headers:
-                kwargs["headers"] = headers
+                req_kwargs["headers"] = headers
             if body:
-                kwargs["content"] = body
+                req_kwargs["content"] = body
 
-            response = await http.request(method, url, **kwargs)
+            response = await http.request(method, url, **req_kwargs)
             await response.aread()
 
             # If still 402 after the SDK's retry, payment failed
@@ -153,56 +127,50 @@ class X402Gateway:
                 except Exception:
                     pass
 
-            return X402Receipt(
+            return X402Result(
                 url=url,
                 amount_cents=amount_cents,
                 network=network,
                 transaction_hash=tx_hash,
                 payer=self._payer,
                 gateway_ref=tx_hash or f"x402_{id(response)}",
+                gateway_type="x402",
                 status_code=response.status_code,
                 response_body=response.text,
                 content_type=response.headers.get("content-type", ""),
             )
 
-    def execute_x402(
+    def execute(
         self,
-        url: str,
         amount_cents: int,
         vendor: str,
         memo: str,
-        method: str = "GET",
-        headers: dict | None = None,
-        body: str | None = None,
-    ) -> X402Receipt:
+        **kwargs,
+    ) -> X402Result:
         """Make a paid HTTP request via the x402 protocol (sync).
 
-        Synchronous wrapper around :meth:`execute_x402_async`. Safe to call
+        Synchronous wrapper around :meth:`execute_async`. Safe to call
         from any context — including scripts, CLI, and environments with a
         running event loop (LangGraph agents, FastAPI handlers, Jupyter
         notebooks). When a loop is already running in the current thread, the
         call is automatically dispatched to a worker thread with its own fresh
         event loop. For fully-async callers that prefer to avoid the thread
-        overhead, ``await gateway.execute_x402_async(...)`` is also available.
+        overhead, ``await gateway.execute_async(...)`` is also available.
 
         Args:
-            url: The x402-enabled endpoint URL.
             amount_cents: Payment amount in cents.
             vendor: Name of the vendor or service.
             memo: Justification or memo for the payment.
-            method: HTTP method (default ``"GET"``).
-            headers: Optional additional HTTP headers.
-            body: Optional request body string.
+            **kwargs: Must include ``url``. Optional: ``method`` (default ``"GET"``),
+                ``headers``, ``body``.
 
         Returns:
-            An ``X402Receipt`` with the response body and transaction details.
+            An ``X402Result`` with the response body and transaction details.
 
         Raises:
             RuntimeError: If the x402 payment fails (still 402 after retry).
         """
-        coro = self.execute_x402_async(
-            url, amount_cents, vendor, memo, method, headers, body
-        )
+        coro = self.execute_async(amount_cents, vendor, memo, **kwargs)
 
         try:
             asyncio.get_running_loop()

--- a/src/paygraph/gateways/x402.py
+++ b/src/paygraph/gateways/x402.py
@@ -64,7 +64,11 @@ class X402Gateway(BaseGateway):
         amount_cents: int,
         vendor: str,
         memo: str,
-        **kwargs,
+        *,
+        url: str = "",
+        method: str = "GET",
+        headers: dict | None = None,
+        body: str | None = None,
     ) -> X402Result:
         """Make a paid HTTP request via the x402 protocol (async).
 
@@ -77,8 +81,10 @@ class X402Gateway(BaseGateway):
             amount_cents: Payment amount in cents.
             vendor: Name of the vendor or service.
             memo: Justification or memo for the payment.
-            **kwargs: Must include ``url``. Optional: ``method`` (default ``"GET"``),
-                ``headers``, ``body``.
+            url: The x402-enabled endpoint URL.
+            method: HTTP method (default ``"GET"``).
+            headers: Optional additional HTTP headers.
+            body: Optional request body string.
 
         Returns:
             An ``X402Result`` with the response body and transaction details.
@@ -86,10 +92,6 @@ class X402Gateway(BaseGateway):
         Raises:
             RuntimeError: If the x402 payment fails (still 402 after retry).
         """
-        url = kwargs.get("url", "")
-        method = kwargs.get("method", "GET")
-        headers = kwargs.get("headers")
-        body = kwargs.get("body")
 
         from x402.http.clients import x402HttpxClient
 
@@ -145,7 +147,11 @@ class X402Gateway(BaseGateway):
         amount_cents: int,
         vendor: str,
         memo: str,
-        **kwargs,
+        *,
+        url: str = "",
+        method: str = "GET",
+        headers: dict | None = None,
+        body: str | None = None,
     ) -> X402Result:
         """Make a paid HTTP request via the x402 protocol (sync).
 
@@ -161,8 +167,10 @@ class X402Gateway(BaseGateway):
             amount_cents: Payment amount in cents.
             vendor: Name of the vendor or service.
             memo: Justification or memo for the payment.
-            **kwargs: Must include ``url``. Optional: ``method`` (default ``"GET"``),
-                ``headers``, ``body``.
+            url: The x402-enabled endpoint URL.
+            method: HTTP method (default ``"GET"``).
+            headers: Optional additional HTTP headers.
+            body: Optional request body string.
 
         Returns:
             An ``X402Result`` with the response body and transaction details.
@@ -170,7 +178,9 @@ class X402Gateway(BaseGateway):
         Raises:
             RuntimeError: If the x402 payment fails (still 402 after retry).
         """
-        coro = self.execute_async(amount_cents, vendor, memo, **kwargs)
+        coro = self.execute_async(
+            amount_cents, vendor, memo, url=url, method=method, headers=headers, body=body
+        )
 
         try:
             asyncio.get_running_loop()

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -6,6 +6,7 @@ from paygraph.exceptions import (
     PolicyViolationError,
     SpendDeniedError,
 )
+from paygraph.gateways.base import BaseGateway, CardResult, SpendResult
 from paygraph.gateways.mock import MockGateway
 from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.policy import PolicyEngine, SpendPolicy
@@ -15,7 +16,8 @@ class AgentWallet:
     """Main entry point for PayGraph spend governance.
 
     Orchestrates policy checks, gateway calls, and audit logging for both
-    virtual card and x402 payment flows.
+    virtual card and x402 payment flows. All gateways share a single
+    ``PolicyEngine``, ensuring a unified daily budget across payment types.
 
     Example:
         ```python
@@ -30,21 +32,19 @@ class AgentWallet:
 
     def __init__(
         self,
-        gateway=None,
-        x402_gateway=None,
+        gateways: dict[str, BaseGateway] | BaseGateway | None = None,
         policy: SpendPolicy | None = None,
         agent_id: str = "default",
         log_path: str = "paygraph_audit.jsonl",
         verbose: bool = True,
         animate: bool = False,
     ) -> None:
-        """Initialize the wallet with a gateway, policy, and audit settings.
+        """Initialize the wallet with gateways, policy, and audit settings.
 
         Args:
-            gateway: Card gateway implementing ``BaseGateway``. Defaults to
-                ``MockGateway()`` which prompts for human approval.
-            x402_gateway: Optional x402 gateway (``X402Gateway`` or
-                ``MockX402Gateway``) for HTTP 402 payments.
+            gateways: A single gateway, a named dict of gateways, or None
+                (defaults to ``{"default": MockGateway()}``). A single gateway
+                is auto-wrapped to ``{"default": gw}``.
             policy: Spend policy rules. Defaults to ``SpendPolicy()`` with
                 $50 max transaction and $200 daily budget.
             agent_id: Identifier for this agent in audit logs.
@@ -53,37 +53,58 @@ class AgentWallet:
             animate: If True, add a short delay between policy checks
                 for visual effect in demos.
         """
-        self.gateway = gateway or MockGateway()
-        self.x402_gateway = x402_gateway
+        if gateways is None:
+            self._gateways: dict[str, BaseGateway] = {"default": MockGateway()}
+        elif isinstance(gateways, BaseGateway):
+            self._gateways = {"default": gateways}
+        else:
+            self._gateways = dict(gateways)
+
         self.policy_engine = PolicyEngine(policy or SpendPolicy())
         self.agent_id = agent_id
         self._audit = AuditLogger(log_path=log_path, verbose=verbose, animate=animate)
 
-    def request_spend(self, amount: float, vendor: str, justification: str) -> str:
-        """Request a policy-checked virtual card spend.
+    @property
+    def gateway(self) -> BaseGateway | None:
+        """Backward-compatible alias for the ``"default"`` gateway."""
+        return self._gateways.get("default")
 
-        Evaluates the spend against the configured policy, then calls the
-        card gateway to mint a virtual card if approved.
+    @gateway.setter
+    def gateway(self, value: BaseGateway) -> None:
+        self._gateways["default"] = value
+
+    def _resolve_gateway(self, name: str) -> BaseGateway:
+        """Look up a gateway by name, raising GatewayError if not found."""
+        gw = self._gateways.get(name)
+        if gw is None:
+            raise GatewayError(
+                f"No gateway named '{name}' configured. "
+                f"Available: {list(self._gateways.keys())}"
+            )
+        return gw
+
+    def _execute_with_policy(
+        self,
+        gateway_name: str,
+        amount: float,
+        vendor: str,
+        justification: str,
+        **gateway_kwargs,
+    ) -> SpendResult:
+        """Shared orchestration: policy → Slack check → gateway → commit → audit.
 
         Args:
-            amount: Dollar amount to spend (e.g. 4.20 for $4.20).
-            vendor: Name of the vendor or service.
-            justification: Explanation of why this purchase is necessary.
+            gateway_name: Key into ``self._gateways``.
+            amount: Dollar amount to spend.
+            vendor: Vendor name.
+            justification: Justification string.
+            **gateway_kwargs: Extra kwargs passed to ``gateway.execute()``.
 
         Returns:
-            For most gateways, a string with card details (PAN, CVV, expiry).
-            For ``stripe_mpp_*`` gateways, a string with the SPT id and spend limit.
-
-        Raises:
-            PolicyViolationError: If the policy engine denies the request.
-            SpendDeniedError: If a human denies the request (MockGateway).
-            GatewayError: If the gateway API call fails.
-            HumanApprovalRequired: If the amount exceeds
-                ``policy.require_human_approval_above`` and a
-                ``SlackApprovalGateway`` is configured. Resume with
-                ``complete_spend(request_id, approved=True)``.
+            The ``SpendResult`` from the gateway.
         """
-        # Print header and run policy engine with live check output
+        gw = self._resolve_gateway(gateway_name)
+
         on_check = (
             self._audit.start_request(amount, vendor) if self._audit.verbose else None
         )
@@ -110,7 +131,7 @@ class AgentWallet:
         if (
             self.policy_engine.policy.require_human_approval_above is not None
             and amount > self.policy_engine.policy.require_human_approval_above
-            and isinstance(self.gateway, SlackApprovalGateway)
+            and isinstance(gw, SlackApprovalGateway)
         ):
             self._audit.log(
                 AuditRecord.now(
@@ -122,14 +143,13 @@ class AgentWallet:
                     checks_passed=result.checks_passed,
                 )
             )
-            self.gateway.request_approval(
+            gw.request_approval(
                 amount_cents, vendor, justification, justification=justification
             )
             # request_approval always raises HumanApprovalRequired — unreachable
 
-        # Mint card — commit the budget only after the gateway succeeds
         try:
-            card = self.gateway.execute_spend(amount_cents, vendor, justification)
+            spend_result = gw.execute(amount_cents, vendor, justification, **gateway_kwargs)
         except SpendDeniedError:
             self._audit.log(
                 AuditRecord.now(
@@ -160,7 +180,6 @@ class AgentWallet:
         # Gateway succeeded — now it is safe to commit the spend to the budget
         self.policy_engine.commit_spend(amount)
 
-        # Log approval
         self._audit.log(
             AuditRecord.now(
                 agent_id=self.agent_id,
@@ -169,19 +188,153 @@ class AgentWallet:
                 justification=justification,
                 policy_result="approved",
                 checks_passed=result.checks_passed,
-                gateway_ref=card.gateway_ref,
-                gateway_type=card.gateway_type,
+                gateway_ref=spend_result.gateway_ref,
+                gateway_type=spend_result.gateway_type,
             )
         )
 
-        if card.gateway_type.startswith("stripe_mpp"):
+        return spend_result
+
+    async def _execute_with_policy_async(
+        self,
+        gateway_name: str,
+        amount: float,
+        vendor: str,
+        justification: str,
+        **gateway_kwargs,
+    ) -> SpendResult:
+        """Async variant of :meth:`_execute_with_policy`.
+
+        Uses ``gateway.execute_async()`` instead of ``gateway.execute()``.
+        """
+        gw = self._resolve_gateway(gateway_name)
+
+        on_check = (
+            self._audit.start_request(amount, vendor) if self._audit.verbose else None
+        )
+        result = self.policy_engine.evaluate(
+            amount, vendor, justification, on_check=on_check
+        )
+
+        if not result.approved:
+            self._audit.log(
+                AuditRecord.now(
+                    agent_id=self.agent_id,
+                    amount=amount,
+                    vendor=vendor,
+                    justification=justification,
+                    policy_result="denied",
+                    denial_reason=result.denial_reason,
+                    checks_passed=result.checks_passed,
+                )
+            )
+            raise PolicyViolationError(result.denial_reason)
+
+        amount_cents = int(round(amount * 100))
+
+        try:
+            spend_result = await gw.execute_async(
+                amount_cents, vendor, justification, **gateway_kwargs
+            )
+        except SpendDeniedError:
+            self._audit.log(
+                AuditRecord.now(
+                    agent_id=self.agent_id,
+                    amount=amount,
+                    vendor=vendor,
+                    justification=justification,
+                    policy_result="denied",
+                    denial_reason="Human denied the x402 payment request",
+                    checks_passed=result.checks_passed,
+                )
+            )
+            raise
+        except Exception as e:
+            self._audit.log(
+                AuditRecord.now(
+                    agent_id=self.agent_id,
+                    amount=amount,
+                    vendor=vendor,
+                    justification=justification,
+                    policy_result="denied",
+                    denial_reason=f"Gateway error: {e}",
+                    checks_passed=result.checks_passed,
+                )
+            )
+            raise GatewayError(str(e)) from e
+
+        self.policy_engine.commit_spend(amount)
+
+        self._audit.log(
+            AuditRecord.now(
+                agent_id=self.agent_id,
+                amount=amount,
+                vendor=vendor,
+                justification=justification,
+                policy_result="approved",
+                checks_passed=result.checks_passed,
+                gateway_ref=spend_result.gateway_ref,
+                gateway_type=spend_result.gateway_type,
+            )
+        )
+
+        return spend_result
+
+    def request_spend(
+        self,
+        amount: float,
+        vendor: str,
+        justification: str,
+        gateway: str = "default",
+    ) -> str:
+        """Request a policy-checked virtual card spend.
+
+        Evaluates the spend against the configured policy, then calls the
+        card gateway to mint a virtual card if approved.
+
+        Args:
+            amount: Dollar amount to spend (e.g. 4.20 for $4.20).
+            vendor: Name of the vendor or service.
+            justification: Explanation of why this purchase is necessary.
+            gateway: Name of the gateway to use (default ``"default"``).
+
+        Returns:
+            For most gateways, a string with card details (PAN, CVV, expiry).
+            For ``stripe_mpp_*`` gateways, a string with the SPT id and spend limit.
+
+        Raises:
+            PolicyViolationError: If the policy engine denies the request.
+            SpendDeniedError: If a human denies the request (MockGateway).
+            GatewayError: If the gateway API call fails.
+            HumanApprovalRequired: If the amount exceeds
+                ``policy.require_human_approval_above`` and a
+                ``SlackApprovalGateway`` is configured. Resume with
+                ``complete_spend(request_id, approved=True)``.
+        """
+        spend_result = self._execute_with_policy(
+            gateway, amount, vendor, justification
+        )
+
+        if isinstance(spend_result, CardResult):
+            if spend_result.gateway_type.startswith("stripe_mpp"):
+                return (
+                    f"SPT approved. Token: {spend_result.gateway_ref} "
+                    f"(spend limit: ${amount:.2f})"
+                )
             return (
-                f"SPT approved. Token: {card.gateway_ref} (spend limit: ${amount:.2f})"
+                f"Card approved. PAN: {spend_result.pan}, "
+                f"CVV: {spend_result.cvv}, Expiry: {spend_result.expiry}"
             )
 
-        return f"Card approved. PAN: {card.pan}, CVV: {card.cvv}, Expiry: {card.expiry}"
+        # Fallback for non-card gateways
+        return f"Spend approved. Ref: {spend_result.gateway_ref}"
 
-    def complete_spend(self, request_id: str, approved: bool) -> str:
+    def complete_spend(
+        self,
+        request_id: str,
+        approved: bool,
+        gateway: str = "default",
+    ) -> str:
         """Resume a spend that was paused for human Slack approval.
 
         Call this after catching ``HumanApprovalRequired`` from
@@ -191,25 +344,27 @@ class AgentWallet:
             request_id: The ``request_id`` from the ``HumanApprovalRequired``
                 exception.
             approved: ``True`` to approve the spend, ``False`` to deny it.
+            gateway: Name of the gateway that initiated the approval.
 
         Returns:
             Card details string if approved (same format as ``request_spend``).
 
         Raises:
-            GatewayError: If no ``SlackApprovalGateway`` is configured.
+            GatewayError: If the gateway is not a ``SlackApprovalGateway``.
             SpendDeniedError: If ``approved`` is ``False``.
         """
-        if not isinstance(self.gateway, SlackApprovalGateway):
+        gw = self._resolve_gateway(gateway)
+        if not isinstance(gw, SlackApprovalGateway):
             raise GatewayError("complete_spend requires a SlackApprovalGateway.")
 
         # Peek at pending metadata before complete_spend() pops it
-        pending = self.gateway.get_pending(request_id)
+        pending = gw.get_pending(request_id)
         amount = pending["amount_cents"] / 100
         vendor = pending["vendor"]
         justification = pending["justification"]
 
         try:
-            card = self.gateway.complete_spend(request_id, approved)
+            card = gw.complete_spend(request_id, approved)
         except SpendDeniedError:
             self._audit.log(
                 AuditRecord.now(
@@ -241,7 +396,10 @@ class AgentWallet:
                 f"SPT approved. Token: {card.gateway_ref} (spend limit: ${amount:.2f})"
             )
 
-        return f"Card approved. PAN: {card.pan}, CVV: {card.cvv}, Expiry: {card.expiry}"
+        if isinstance(card, CardResult):
+            return f"Card approved. PAN: {card.pan}, CVV: {card.cvv}, Expiry: {card.expiry}"
+
+        return f"Spend approved. Ref: {card.gateway_ref}"
 
     @cached_property
     def spend_tool(self):
@@ -295,6 +453,7 @@ class AgentWallet:
         method: str = "GET",
         headers: dict | None = None,
         body: str | None = None,
+        gateway: str = "x402",
     ) -> str:
         """Make a policy-checked x402 payment to a paid HTTP endpoint (sync).
 
@@ -311,6 +470,7 @@ class AgentWallet:
             method: HTTP method (default ``"GET"``).
             headers: Optional additional HTTP headers.
             body: Optional request body string.
+            gateway: Name of the x402 gateway (default ``"x402"``).
 
         Returns:
             The response body from the paid resource.
@@ -320,87 +480,17 @@ class AgentWallet:
             PolicyViolationError: If the policy engine denies the request.
             SpendDeniedError: If a human denies the request (MockX402Gateway).
         """
-        if self.x402_gateway is None:
-            raise GatewayError(
-                "No x402 gateway configured. Pass x402_gateway to AgentWallet."
-            )
+        kwargs: dict = {"url": url, "method": method}
+        if headers:
+            kwargs["headers"] = headers
+        if body:
+            kwargs["body"] = body
 
-        on_check = (
-            self._audit.start_request(amount, vendor) if self._audit.verbose else None
-        )
-        result = self.policy_engine.evaluate(
-            amount, vendor, justification, on_check=on_check
+        spend_result = self._execute_with_policy(
+            gateway, amount, vendor, justification, **kwargs
         )
 
-        if not result.approved:
-            self._audit.log(
-                AuditRecord.now(
-                    agent_id=self.agent_id,
-                    amount=amount,
-                    vendor=vendor,
-                    justification=justification,
-                    policy_result="denied",
-                    denial_reason=result.denial_reason,
-                    checks_passed=result.checks_passed,
-                )
-            )
-            raise PolicyViolationError(result.denial_reason)
-
-        amount_cents = int(round(amount * 100))
-        try:
-            receipt = self.x402_gateway.execute_x402(
-                url,
-                amount_cents,
-                vendor,
-                justification,
-                method=method,
-                headers=headers,
-                body=body,
-            )
-        except SpendDeniedError:
-            self._audit.log(
-                AuditRecord.now(
-                    agent_id=self.agent_id,
-                    amount=amount,
-                    vendor=vendor,
-                    justification=justification,
-                    policy_result="denied",
-                    denial_reason="Human denied the x402 payment request",
-                    checks_passed=result.checks_passed,
-                )
-            )
-            raise
-        except Exception as e:
-            self._audit.log(
-                AuditRecord.now(
-                    agent_id=self.agent_id,
-                    amount=amount,
-                    vendor=vendor,
-                    justification=justification,
-                    policy_result="denied",
-                    denial_reason=f"Gateway error: {e}",
-                    checks_passed=result.checks_passed,
-                )
-            )
-            raise GatewayError(str(e)) from e
-
-        # Gateway succeeded — now it is safe to commit the spend to the budget
-        self.policy_engine.commit_spend(amount)
-
-        self._audit.log(
-            AuditRecord.now(
-                agent_id=self.agent_id,
-                amount=amount,
-                vendor=vendor,
-                justification=justification,
-                policy_result="approved",
-                checks_passed=result.checks_passed,
-                gateway_ref=receipt.gateway_ref,
-                gateway_type=receipt.gateway_type,
-            )
-        )
-
-        return receipt.response_body
+        return spend_result.response_body
 
     async def request_x402_async(
         self,
@@ -411,6 +501,7 @@ class AgentWallet:
         method: str = "GET",
         headers: dict | None = None,
         body: str | None = None,
+        gateway: str = "x402",
     ) -> str:
         """Make a policy-checked x402 payment to a paid HTTP endpoint (async).
 
@@ -426,6 +517,7 @@ class AgentWallet:
             method: HTTP method (default ``"GET"``).
             headers: Optional additional HTTP headers.
             body: Optional request body string.
+            gateway: Name of the x402 gateway (default ``"x402"``).
 
         Returns:
             The response body from the paid resource.
@@ -435,87 +527,17 @@ class AgentWallet:
             PolicyViolationError: If the policy engine denies the request.
             SpendDeniedError: If a human denies the request (MockX402Gateway).
         """
-        if self.x402_gateway is None:
-            raise GatewayError(
-                "No x402 gateway configured. Pass x402_gateway to AgentWallet."
-            )
+        kwargs: dict = {"url": url, "method": method}
+        if headers:
+            kwargs["headers"] = headers
+        if body:
+            kwargs["body"] = body
 
-        on_check = (
-            self._audit.start_request(amount, vendor) if self._audit.verbose else None
-        )
-        result = self.policy_engine.evaluate(
-            amount, vendor, justification, on_check=on_check
+        spend_result = await self._execute_with_policy_async(
+            gateway, amount, vendor, justification, **kwargs
         )
 
-        if not result.approved:
-            self._audit.log(
-                AuditRecord.now(
-                    agent_id=self.agent_id,
-                    amount=amount,
-                    vendor=vendor,
-                    justification=justification,
-                    policy_result="denied",
-                    denial_reason=result.denial_reason,
-                    checks_passed=result.checks_passed,
-                )
-            )
-            raise PolicyViolationError(result.denial_reason)
-
-        amount_cents = int(round(amount * 100))
-
-        try:
-            receipt = await self.x402_gateway.execute_x402_async(
-                url,
-                amount_cents,
-                vendor,
-                justification,
-                method=method,
-                headers=headers,
-                body=body,
-            )
-        except SpendDeniedError:
-            self._audit.log(
-                AuditRecord.now(
-                    agent_id=self.agent_id,
-                    amount=amount,
-                    vendor=vendor,
-                    justification=justification,
-                    policy_result="denied",
-                    denial_reason="Human denied the x402 payment request",
-                    checks_passed=result.checks_passed,
-                )
-            )
-            raise
-        except Exception as e:
-            self._audit.log(
-                AuditRecord.now(
-                    agent_id=self.agent_id,
-                    amount=amount,
-                    vendor=vendor,
-                    justification=justification,
-                    policy_result="denied",
-                    denial_reason=f"Gateway error: {e}",
-                    checks_passed=result.checks_passed,
-                )
-            )
-            raise GatewayError(str(e)) from e
-
-        self.policy_engine.commit_spend(amount)
-
-        self._audit.log(
-            AuditRecord.now(
-                agent_id=self.agent_id,
-                amount=amount,
-                vendor=vendor,
-                justification=justification,
-                policy_result="approved",
-                checks_passed=result.checks_passed,
-                gateway_ref=receipt.gateway_ref,
-                gateway_type=receipt.gateway_type,
-            )
-        )
-
-        return receipt.response_body
+        return spend_result.response_body
 
     @cached_property
     def crewai_tool(self):
@@ -560,7 +582,7 @@ class AgentWallet:
         """LangChain-compatible tool for x402 HTTP payments.
 
         Returns a ``@tool``-decorated function usable in LangGraph agents.
-        Requires ``langchain-core`` and an ``x402_gateway`` to be configured.
+        Requires ``langchain-core`` and an x402 gateway to be configured.
         """
         return self._build_x402_tool()
 

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from paygraph.audit import AuditLogger, AuditRecord
 from paygraph.exceptions import (
     GatewayError,
+    HumanApprovalRequired,
     PolicyViolationError,
     SpendDeniedError,
 )
@@ -143,9 +144,13 @@ class AgentWallet:
                     checks_passed=result.checks_passed,
                 )
             )
-            gw.request_approval(
-                amount_cents, vendor, justification, justification=justification
-            )
+            try:
+                gw.request_approval(
+                    amount_cents, vendor, justification, justification=justification
+                )
+            except HumanApprovalRequired as e:
+                e.gateway_name = gateway_name
+                raise
             # request_approval always raises HumanApprovalRequired — unreachable
 
         try:
@@ -345,6 +350,8 @@ class AgentWallet:
                 exception.
             approved: ``True`` to approve the spend, ``False`` to deny it.
             gateway: Name of the gateway that initiated the approval.
+                Use ``e.gateway_name`` from the ``HumanApprovalRequired``
+                exception to resolve the correct gateway.
 
         Returns:
             Card details string if approved (same format as ``request_spend``).

--- a/tests/test_crewai.py
+++ b/tests/test_crewai.py
@@ -13,7 +13,7 @@ class TestCrewAITool:
 
     def test_crewai_tool_raises_import_error_without_crewai(self):
         """crewai_tool raises a helpful ImportError when crewai is not installed."""
-        wallet = AgentWallet(gateway=MockGateway(auto_approve=True))
+        wallet = AgentWallet(gateways=MockGateway(auto_approve=True))
 
         with patch.dict("sys.modules", {"crewai": None, "crewai.tools": None}):
             # Clear cached property so it re-evaluates
@@ -31,7 +31,7 @@ class TestCrewAITool:
         mock_crewai.tools = MagicMock()
         mock_crewai.tools.Tool = mock_crewai_tool_cls
 
-        wallet = AgentWallet(gateway=MockGateway(auto_approve=True))
+        wallet = AgentWallet(gateways=MockGateway(auto_approve=True))
         # Clear cached properties
         wallet.__dict__.pop("crewai_tool", None)
         wallet.__dict__.pop("spend_tool", None)

--- a/tests/test_mock_gateway.py
+++ b/tests/test_mock_gateway.py
@@ -7,7 +7,7 @@ from paygraph.gateways.mock import MockGateway
 class TestAutoApprove:
     def test_mints_card_without_prompt(self):
         gw = MockGateway(auto_approve=True)
-        card = gw.execute_spend(420, "Anthropic", "test")
+        card = gw.execute(420, "Anthropic", "test")
         assert card.pan == "4111111111111111"
         assert card.cvv == "123"
         assert card.expiry == "12/28"
@@ -17,8 +17,8 @@ class TestAutoApprove:
 
     def test_unique_tokens(self):
         gw = MockGateway(auto_approve=True)
-        c1 = gw.execute_spend(100, "v", "m")
-        c2 = gw.execute_spend(100, "v", "m")
+        c1 = gw.execute(100, "v", "m")
+        c2 = gw.execute(100, "v", "m")
         assert c1.gateway_ref != c2.gateway_ref
 
 
@@ -26,38 +26,38 @@ class TestManualApproval:
     def test_y_approves(self, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "y")
         gw = MockGateway(auto_approve=False)
-        card = gw.execute_spend(100, "vendor", "memo")
+        card = gw.execute(100, "vendor", "memo")
         assert card.pan == "4111111111111111"
 
     def test_empty_approves(self, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "")
         gw = MockGateway(auto_approve=False)
-        card = gw.execute_spend(100, "vendor", "memo")
+        card = gw.execute(100, "vendor", "memo")
         assert card.pan == "4111111111111111"
 
     def test_yes_approves(self, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "yes")
         gw = MockGateway(auto_approve=False)
-        card = gw.execute_spend(100, "vendor", "memo")
+        card = gw.execute(100, "vendor", "memo")
         assert card.pan is not None
 
     def test_n_denies(self, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "n")
         gw = MockGateway(auto_approve=False)
         with pytest.raises(SpendDeniedError, match="denied"):
-            gw.execute_spend(100, "vendor", "memo")
+            gw.execute(100, "vendor", "memo")
 
     def test_no_denies(self, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "no")
         gw = MockGateway(auto_approve=False)
         with pytest.raises(SpendDeniedError):
-            gw.execute_spend(100, "vendor", "memo")
+            gw.execute(100, "vendor", "memo")
 
 
 class TestRevoke:
     def test_revoke_existing(self):
         gw = MockGateway(auto_approve=True)
-        card = gw.execute_spend(100, "v", "m")
+        card = gw.execute(100, "v", "m")
         assert gw.revoke(card.gateway_ref) is True
 
     def test_revoke_nonexistent(self):
@@ -66,6 +66,6 @@ class TestRevoke:
 
     def test_revoke_twice(self):
         gw = MockGateway(auto_approve=True)
-        card = gw.execute_spend(100, "v", "m")
+        card = gw.execute(100, "v", "m")
         assert gw.revoke(card.gateway_ref) is True
         assert gw.revoke(card.gateway_ref) is False

--- a/tests/test_slack_gateway.py
+++ b/tests/test_slack_gateway.py
@@ -31,7 +31,7 @@ def _make_slack_wallet(
         inner_gateway=inner_gateway or MockGateway(auto_approve=True),
     )
     wallet = AgentWallet(
-        gateway=gateway,
+        gateways=gateway,
         policy=policy or SpendPolicy(require_human_approval_above=20.0),
         log_path=f.name,
         verbose=False,
@@ -230,7 +230,7 @@ class TestWalletSlackFlow:
         f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
         f.close()
         wallet = AgentWallet(
-            gateway=MockGateway(auto_approve=True),
+            gateways=MockGateway(auto_approve=True),
             log_path=f.name,
             verbose=False,
         )

--- a/tests/test_stripe_gateway.py
+++ b/tests/test_stripe_gateway.py
@@ -70,7 +70,7 @@ class TestCardholderCreation:
         ]
 
         gw = StripeCardGateway(api_key="sk_test_xxx")
-        gw.execute_spend(420, "Anthropic", "API credits")
+        gw.execute(420, "Anthropic", "API credits")
 
         # Verify cardholder POST was called
         cardholder_posts = [
@@ -93,7 +93,7 @@ class TestCardholderCreation:
         mock_client.post.return_value = _mock_response(200, _CARD_CREATE_JSON)
 
         gw = StripeCardGateway(api_key="sk_test_xxx")
-        gw.execute_spend(420, "Anthropic", "API credits")
+        gw.execute(420, "Anthropic", "API credits")
 
         # No cardholder POST — reused existing
         cardholder_posts = [
@@ -122,8 +122,8 @@ class TestCardholderCreation:
         ]
 
         gw = StripeCardGateway(api_key="sk_test_xxx")
-        gw.execute_spend(420, "Anthropic", "API credits")
-        gw.execute_spend(100, "OpenAI", "Tokens")
+        gw.execute(420, "Anthropic", "API credits")
+        gw.execute(100, "OpenAI", "Tokens")
 
         # Cardholder POST only called once
         cardholder_posts = [
@@ -142,7 +142,7 @@ class TestCardholderCreation:
         mock_client.get.return_value = _mock_response(200, _CARD_DETAIL_JSON)
 
         gw = StripeCardGateway(api_key="sk_test_xxx", cardholder_id="ich_xxx")
-        gw.execute_spend(420, "Anthropic", "API credits")
+        gw.execute(420, "Anthropic", "API credits")
 
         # No cardholder list GET or POST
         get_calls = mock_client.get.call_args_list
@@ -165,7 +165,7 @@ class TestExecuteSpend:
         mock_client.get.return_value = _mock_response(200, _CARD_DETAIL_JSON)
 
         gw = StripeCardGateway(api_key="sk_test_xxx", cardholder_id="ich_xxx")
-        card = gw.execute_spend(420, "Anthropic", "API credits")
+        card = gw.execute(420, "Anthropic", "API credits")
 
         assert card.pan == "4242424242424242"
         assert card.cvv == "789"
@@ -185,8 +185,8 @@ class TestExecuteSpend:
         gw = StripeCardGateway(
             api_key="sk_test_xxx", cardholder_id="ich_xxx", single_use=True
         )
-        gw.execute_spend(420, "Anthropic", "API credits")
-        gw.execute_spend(100, "OpenAI", "Tokens")
+        gw.execute(420, "Anthropic", "API credits")
+        gw.execute(100, "OpenAI", "Tokens")
 
         # Two card creation POSTs
         card_posts = [
@@ -208,8 +208,8 @@ class TestExecuteSpend:
         gw = StripeCardGateway(
             api_key="sk_test_xxx", cardholder_id="ich_xxx", single_use=False
         )
-        card1 = gw.execute_spend(420, "Anthropic", "API credits")
-        card2 = gw.execute_spend(100, "OpenAI", "Tokens")
+        card1 = gw.execute(420, "Anthropic", "API credits")
+        card2 = gw.execute(100, "OpenAI", "Tokens")
 
         # Only one card creation POST
         card_creates = [
@@ -241,7 +241,7 @@ class TestExecuteSpend:
             cardholder_id="ich_xxx",
             allowed_mccs=["7372", "5734"],
         )
-        gw.execute_spend(420, "Anthropic", "API credits")
+        gw.execute(420, "Anthropic", "API credits")
 
         card_post = [
             c for c in mock_client.post.call_args_list if c[0][0] == "/v1/issuing/cards"
@@ -263,7 +263,7 @@ class TestExecuteSpend:
             cardholder_id="ich_xxx",
             blocked_mccs=["7995", "5813"],
         )
-        gw.execute_spend(420, "Anthropic", "API credits")
+        gw.execute(420, "Anthropic", "API credits")
 
         card_post = [
             c for c in mock_client.post.call_args_list if c[0][0] == "/v1/issuing/cards"
@@ -281,7 +281,7 @@ class TestExecuteSpend:
         mock_client.get.return_value = _mock_response(200, _CARD_DETAIL_JSON)
 
         gw = StripeCardGateway(api_key="sk_test_xxx", cardholder_id="ich_xxx")
-        gw.execute_spend(420, "Anthropic", "API credits")
+        gw.execute(420, "Anthropic", "API credits")
 
         card_post = [
             c for c in mock_client.post.call_args_list if c[0][0] == "/v1/issuing/cards"
@@ -300,7 +300,7 @@ class TestExecuteSpend:
 
         gw = StripeCardGateway(api_key="sk_test_xxx", cardholder_id="ich_xxx")
         with pytest.raises(GatewayError, match="Stripe API error: Invalid card params"):
-            gw.execute_spend(420, "vendor", "memo")
+            gw.execute(420, "vendor", "memo")
 
     @patch("paygraph.gateways.stripe.httpx.Client")
     def test_network_error(self, mock_client_cls):
@@ -310,7 +310,7 @@ class TestExecuteSpend:
 
         gw = StripeCardGateway(api_key="sk_test_xxx", cardholder_id="ich_xxx")
         with pytest.raises(GatewayError, match="Stripe API unreachable"):
-            gw.execute_spend(420, "vendor", "memo")
+            gw.execute(420, "vendor", "memo")
 
 
 class TestRevoke:

--- a/tests/test_stripe_mpp_gateway.py
+++ b/tests/test_stripe_mpp_gateway.py
@@ -97,7 +97,7 @@ class TestExecuteSpend:
         with patch(
             "paygraph.gateways.stripe_mpp.time.time", return_value=1_700_000_000
         ):
-            card = gw.execute_spend(420, "Anthropic", "API credits")
+            card = gw.execute(420, "Anthropic", "API credits")
 
         assert card.pan == "SPT_NO_PAN"
         assert card.cvv == "N/A"
@@ -134,7 +134,7 @@ class TestExecuteSpend:
         )
         long_vendor = "V" * 150
         long_memo = "M" * 600
-        gw.execute_spend(100, long_vendor, long_memo)
+        gw.execute(100, long_vendor, long_memo)
         data = mock_client.post.call_args[1]["data"]
         assert len(data["metadata[vendor]"]) == 100
         assert len(data["metadata[memo]"]) == 500
@@ -153,7 +153,7 @@ class TestExecuteSpend:
             grantee="profile_x",
         )
         with pytest.raises(GatewayError, match="Stripe API error: invalid_grantee"):
-            gw.execute_spend(100, "v", "m")
+            gw.execute(100, "v", "m")
 
     @patch("paygraph.gateways.stripe_mpp.httpx.Client")
     def test_http_error_with_non_json_body(self, mock_client_cls):
@@ -169,7 +169,7 @@ class TestExecuteSpend:
             grantee="profile_x",
         )
         with pytest.raises(GatewayError, match="Stripe API error:"):
-            gw.execute_spend(100, "v", "m")
+            gw.execute(100, "v", "m")
 
     @patch("paygraph.gateways.stripe_mpp.httpx.Client")
     def test_missing_id_in_response(self, mock_client_cls):
@@ -183,7 +183,7 @@ class TestExecuteSpend:
             grantee="profile_x",
         )
         with pytest.raises(GatewayError, match="no token id"):
-            gw.execute_spend(100, "v", "m")
+            gw.execute(100, "v", "m")
 
     @patch("paygraph.gateways.stripe_mpp.httpx.Client")
     def test_network_error(self, mock_client_cls):
@@ -197,7 +197,7 @@ class TestExecuteSpend:
             grantee="profile_x",
         )
         with pytest.raises(GatewayError, match="Stripe API unreachable"):
-            gw.execute_spend(100, "v", "m")
+            gw.execute(100, "v", "m")
 
     @patch("paygraph.gateways.stripe_mpp.httpx.Client")
     def test_omits_empty_vendor_and_memo_metadata(self, mock_client_cls):
@@ -210,7 +210,7 @@ class TestExecuteSpend:
             payment_method="pm_x",
             grantee="profile_x",
         )
-        gw.execute_spend(100, "", "")
+        gw.execute(100, "", "")
         data = mock_client.post.call_args[1]["data"]
         assert "metadata[vendor]" not in data
         assert "metadata[memo]" not in data

--- a/tests/test_unified_budget.py
+++ b/tests/test_unified_budget.py
@@ -1,0 +1,101 @@
+"""Tests proving that card + x402 gateways share a single PolicyEngine budget."""
+
+import json
+import tempfile
+
+import pytest
+
+from paygraph.exceptions import PolicyViolationError
+from paygraph.gateways.mock import MockGateway
+from paygraph.gateways.mock_x402 import MockX402Gateway
+from paygraph.policy import SpendPolicy
+from paygraph.wallet import AgentWallet
+
+
+def _make_wallet(gateways, policy=None, **kwargs) -> tuple[AgentWallet, str]:
+    f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+    f.close()
+    return (
+        AgentWallet(
+            gateways=gateways,
+            policy=policy or SpendPolicy(),
+            log_path=f.name,
+            verbose=False,
+            **kwargs,
+        ),
+        f.name,
+    )
+
+
+def _read_audit(path: str) -> list[dict]:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+class TestCrossGatewayBudgetTracking:
+    def test_card_and_x402_share_daily_budget(self):
+        """Card + x402 spends draw from the same daily budget."""
+        wallet, _ = _make_wallet(
+            gateways={
+                "default": MockGateway(auto_approve=True),
+                "x402": MockX402Gateway(auto_approve=True),
+            },
+            policy=SpendPolicy(daily_budget=10.0, max_transaction=50.0),
+        )
+        wallet.request_spend(6.0, "vendor", "reason")  # $6 via card
+        wallet.request_x402(
+            "https://api.example.com", 3.0, "vendor", "reason"
+        )  # $3 via x402
+        with pytest.raises(PolicyViolationError, match="Daily budget"):
+            wallet.request_spend(5.0, "vendor", "reason")  # $5 should fail
+
+    def test_x402_then_card_share_budget(self):
+        """x402 spend first, then card — budget is shared."""
+        wallet, _ = _make_wallet(
+            gateways={
+                "default": MockGateway(auto_approve=True),
+                "x402": MockX402Gateway(auto_approve=True),
+            },
+            policy=SpendPolicy(daily_budget=10.0, max_transaction=50.0),
+        )
+        wallet.request_x402(
+            "https://api.example.com", 8.0, "vendor", "reason"
+        )  # $8 via x402
+        with pytest.raises(PolicyViolationError, match="Daily budget"):
+            wallet.request_spend(5.0, "vendor", "reason")  # $5 should fail
+
+    def test_multiple_gateways_all_share_budget(self):
+        """Three gateways all share the same PolicyEngine."""
+        wallet, _ = _make_wallet(
+            gateways={
+                "card1": MockGateway(auto_approve=True),
+                "card2": MockGateway(auto_approve=True),
+                "x402": MockX402Gateway(auto_approve=True),
+            },
+            policy=SpendPolicy(daily_budget=15.0, max_transaction=50.0),
+        )
+        wallet.request_spend(5.0, "v", "r", gateway="card1")
+        wallet.request_spend(5.0, "v", "r", gateway="card2")
+        wallet.request_x402("https://api.example.com", 4.0, "v", "r")
+        # Total: $14 of $15 budget used
+        with pytest.raises(PolicyViolationError, match="Daily budget"):
+            wallet.request_spend(5.0, "v", "r", gateway="card1")  # $5 over budget
+
+    def test_audit_records_different_gateway_types(self):
+        """Audit log captures correct gateway_type for each gateway."""
+        wallet, path = _make_wallet(
+            gateways={
+                "default": MockGateway(auto_approve=True),
+                "x402": MockX402Gateway(auto_approve=True),
+            },
+            policy=SpendPolicy(daily_budget=100.0, max_transaction=50.0),
+        )
+        wallet.request_spend(5.0, "CardVendor", "card reason")
+        wallet.request_x402("https://api.example.com", 3.0, "X402Vendor", "x402 reason")
+
+        records = _read_audit(path)
+        assert len(records) == 2
+        assert records[0]["gateway_type"] == "mock"
+        assert records[0]["vendor"] == "CardVendor"
+        assert records[1]["gateway_type"] == "x402"
+        assert records[1]["vendor"] == "X402Vendor"

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -4,19 +4,19 @@ import tempfile
 import pytest
 
 from paygraph.exceptions import GatewayError, PolicyViolationError, SpendDeniedError
-from paygraph.gateways.base import BaseGateway, VirtualCard
+from paygraph.gateways.base import BaseGateway, CardResult
 from paygraph.gateways.mock import MockGateway
 from paygraph.policy import SpendPolicy
 from paygraph.wallet import AgentWallet
 
 
-def _make_wallet(gateway=None, policy=None, **kwargs) -> tuple[AgentWallet, str]:
+def _make_wallet(gateways=None, policy=None, **kwargs) -> tuple[AgentWallet, str]:
     """Create a wallet with a temp audit file. Returns (wallet, audit_path)."""
     f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
     f.close()
     return (
         AgentWallet(
-            gateway=gateway or MockGateway(auto_approve=True),
+            gateways=gateways or MockGateway(auto_approve=True),
             policy=policy or SpendPolicy(),
             log_path=f.name,
             verbose=False,
@@ -53,20 +53,18 @@ class TestApprovedSpend:
 
     def test_returns_spt_token_string_for_mpp_gateway(self):
         class MppGateway(BaseGateway):
-            def execute_spend(self, amount_cents, vendor, memo):
-                return VirtualCard(
+            def execute(self, amount_cents, vendor, memo, **kwargs):
+                return CardResult(
                     pan="SPT_NO_PAN",
                     cvv="N/A",
                     expiry="--/--",
                     spend_limit_cents=amount_cents,
+                    amount_cents=amount_cents,
                     gateway_ref="spt_test_abc123",
                     gateway_type="stripe_mpp_test",
                 )
 
-            def revoke(self, gateway_ref):
-                return True
-
-        wallet, _ = _make_wallet(gateway=MppGateway())
+        wallet, _ = _make_wallet(gateways=MppGateway())
         result = wallet.request_spend(4.20, "Anthropic", "need credits")
         assert result == "SPT approved. Token: spt_test_abc123 (spend limit: $4.20)"
 
@@ -90,13 +88,13 @@ class TestPolicyDenial:
 class TestHumanDenial:
     def test_raises_spend_denied(self, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "n")
-        wallet, _ = _make_wallet(gateway=MockGateway(auto_approve=False))
+        wallet, _ = _make_wallet(gateways=MockGateway(auto_approve=False))
         with pytest.raises(SpendDeniedError):
             wallet.request_spend(4.20, "Anthropic", "need credits")
 
     def test_audit_records_human_denial(self, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "n")
-        wallet, path = _make_wallet(gateway=MockGateway(auto_approve=False))
+        wallet, path = _make_wallet(gateways=MockGateway(auto_approve=False))
         with pytest.raises(SpendDeniedError):
             wallet.request_spend(4.20, "Anthropic", "need credits")
         records = _read_audit(path)
@@ -108,25 +106,19 @@ class TestHumanDenial:
 class TestGatewayFailure:
     def test_raises_gateway_error(self):
         class BrokenGateway(BaseGateway):
-            def execute_spend(self, amount_cents, vendor, memo):
+            def execute(self, amount_cents, vendor, memo, **kwargs):
                 raise RuntimeError("connection refused")
 
-            def revoke(self, gateway_ref):
-                return False
-
-        wallet, _ = _make_wallet(gateway=BrokenGateway())
+        wallet, _ = _make_wallet(gateways=BrokenGateway())
         with pytest.raises(GatewayError, match="connection refused"):
             wallet.request_spend(4.20, "vendor", "reason")
 
     def test_audit_records_gateway_failure(self):
         class BrokenGateway(BaseGateway):
-            def execute_spend(self, amount_cents, vendor, memo):
+            def execute(self, amount_cents, vendor, memo, **kwargs):
                 raise RuntimeError("timeout")
 
-            def revoke(self, gateway_ref):
-                return False
-
-        wallet, path = _make_wallet(gateway=BrokenGateway())
+        wallet, path = _make_wallet(gateways=BrokenGateway())
         with pytest.raises(GatewayError):
             wallet.request_spend(4.20, "vendor", "reason")
         records = _read_audit(path)
@@ -139,14 +131,11 @@ class TestGatewayFailureDoesNotConsumeBudget:
         """A gateway failure must not consume the daily budget (issue #9)."""
 
         class BrokenGateway(BaseGateway):
-            def execute_spend(self, amount_cents, vendor, memo):
+            def execute(self, amount_cents, vendor, memo, **kwargs):
                 raise RuntimeError("network timeout")
 
-            def revoke(self, gateway_ref):
-                return False
-
         policy = SpendPolicy(max_transaction=50.0, daily_budget=100.0)
-        wallet, _ = _make_wallet(gateway=BrokenGateway(), policy=policy)
+        wallet, _ = _make_wallet(gateways=BrokenGateway(), policy=policy)
 
         with pytest.raises(GatewayError):
             wallet.request_spend(40.0, "vendor", "reason")

--- a/tests/test_x402.py
+++ b/tests/test_x402.py
@@ -5,8 +5,9 @@ import tempfile
 import pytest
 
 from paygraph.exceptions import GatewayError, PolicyViolationError, SpendDeniedError
+from paygraph.gateways.base import BaseGateway, X402Result
 from paygraph.gateways.mock_x402 import MockX402Gateway
-from paygraph.gateways.x402 import X402Gateway, X402Receipt
+from paygraph.gateways.x402 import X402Gateway
 from paygraph.policy import SpendPolicy
 from paygraph.wallet import AgentWallet
 
@@ -17,14 +18,15 @@ from paygraph.wallet import AgentWallet
 
 def _fake_receipt(
     url: str = "https://api.example.com", amount_cents: int = 100
-) -> X402Receipt:
-    return X402Receipt(
+) -> X402Result:
+    return X402Result(
         url=url,
         amount_cents=amount_cents,
         network="eip155:8453",
         transaction_hash="0xfakehash",
         payer="0xFakePayer",
         gateway_ref="0xfakehash",
+        gateway_type="x402",
     )
 
 
@@ -34,26 +36,27 @@ class _FakeX402Gateway(X402Gateway):
     def __init__(self) -> None:
         self._payer = "0xFakePayer"
 
-    async def execute_x402_async(
+    async def execute_async(
         self,
-        url: str,
         amount_cents: int,
         vendor: str,
         memo: str,
-        method: str = "GET",
-        headers: dict | None = None,
-        body: str | None = None,
-    ) -> X402Receipt:
+        **kwargs,
+    ) -> X402Result:
+        url = kwargs.get("url", "https://api.example.com")
         return _fake_receipt(url, amount_cents)
 
 
-def _make_wallet(x402_gateway=None, policy=None, **kwargs) -> tuple[AgentWallet, str]:
+def _make_wallet(
+    x402_gateway=None, policy=None, **kwargs
+) -> tuple[AgentWallet, str]:
     """Create a wallet with x402 gateway and a temp audit file."""
     f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
     f.close()
+    gw = x402_gateway if x402_gateway is not None else MockX402Gateway(auto_approve=True)
     return (
         AgentWallet(
-            x402_gateway=x402_gateway or MockX402Gateway(auto_approve=True),
+            gateways={"default": MockX402Gateway(auto_approve=True), "x402": gw},
             policy=policy or SpendPolicy(),
             log_path=f.name,
             verbose=False,
@@ -71,10 +74,11 @@ def _read_audit(path: str) -> list[dict]:
 class TestMockX402Gateway:
     def test_returns_receipt(self):
         gw = MockX402Gateway(auto_approve=True, response_body='{"result": "ok"}')
-        receipt = gw.execute_x402(
-            "https://api.example.com/data", 500, "ExampleAPI", "need data"
+        receipt = gw.execute(
+            500, "ExampleAPI", "need data",
+            url="https://api.example.com/data",
         )
-        assert isinstance(receipt, X402Receipt)
+        assert isinstance(receipt, X402Result)
         assert receipt.url == "https://api.example.com/data"
         assert receipt.amount_cents == 500
         assert receipt.gateway_type == "x402"
@@ -86,12 +90,12 @@ class TestMockX402Gateway:
         monkeypatch.setattr("builtins.input", lambda _: "n")
         gw = MockX402Gateway(auto_approve=False)
         with pytest.raises(SpendDeniedError, match="Human denied"):
-            gw.execute_x402("https://api.example.com", 100, "vendor", "reason")
+            gw.execute(100, "vendor", "reason", url="https://api.example.com")
 
     def test_human_approval(self, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "y")
         gw = MockX402Gateway(auto_approve=False)
-        receipt = gw.execute_x402("https://api.example.com", 100, "vendor", "reason")
+        receipt = gw.execute(100, "vendor", "reason", url="https://api.example.com")
         assert receipt.status_code == 200
 
 
@@ -155,8 +159,8 @@ class TestRequestX402HumanDenial:
 
 class TestRequestX402GatewayError:
     def test_raises_gateway_error(self):
-        class BrokenX402Gateway:
-            def execute_x402(self, *args, **kwargs):
+        class BrokenX402Gateway(BaseGateway):
+            def execute(self, amount_cents, vendor, memo, **kwargs):
                 raise RuntimeError("connection refused")
 
         wallet, _ = _make_wallet(x402_gateway=BrokenX402Gateway())
@@ -166,8 +170,6 @@ class TestRequestX402GatewayError:
 
 class TestRequestX402NoGateway:
     def test_raises_when_no_x402_gateway(self):
-        wallet, _ = _make_wallet(x402_gateway=None)
-        # Override — _make_wallet defaults to MockX402Gateway, so make one without
         f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
         f.close()
         wallet = AgentWallet(
@@ -175,7 +177,7 @@ class TestRequestX402NoGateway:
             log_path=f.name,
             verbose=False,
         )
-        with pytest.raises(GatewayError, match="No x402 gateway configured"):
+        with pytest.raises(GatewayError, match="No gateway named 'x402'"):
             wallet.request_x402("https://api.example.com", 4.20, "vendor", "reason")
 
 
@@ -211,41 +213,41 @@ class TestRequestX402HttpMethod:
 
 
 class TestX402GatewaySyncDispatch:
-    """execute_x402() must work both with and without a running event loop."""
+    """execute() must work both with and without a running event loop."""
 
     def test_sync_call_without_running_loop(self):
         """Standard sync call (scripts, CLI) should return a receipt via asyncio.run()."""
         gw = _FakeX402Gateway()
-        result = gw.execute_x402("https://api.example.com", 100, "vendor", "memo")
-        assert isinstance(result, X402Receipt)
+        result = gw.execute(100, "vendor", "memo", url="https://api.example.com")
+        assert isinstance(result, X402Result)
         assert result.url == "https://api.example.com"
         assert result.amount_cents == 100
         assert result.transaction_hash == "0xfakehash"
 
     def test_sync_call_from_running_loop_does_not_raise(self):
-        """execute_x402() called from within a running loop must not raise RuntimeError.
+        """execute() called from within a running loop must not raise RuntimeError.
 
         Simulates the LangGraph / FastAPI scenario where an event loop is already
         running in the current thread when the sync method is invoked.
         """
         gw = _FakeX402Gateway()
 
-        async def call_sync_inside_loop() -> X402Receipt:
+        async def call_sync_inside_loop() -> X402Result:
             # Deliberately calls the *sync* wrapper from inside a coroutine to
             # replicate the nested-loop scenario.
-            return gw.execute_x402("https://api.example.com", 200, "vendor", "memo")
+            return gw.execute(200, "vendor", "memo", url="https://api.example.com")
 
         result = asyncio.run(call_sync_inside_loop())
-        assert isinstance(result, X402Receipt)
+        assert isinstance(result, X402Result)
         assert result.amount_cents == 200
 
     def test_sync_call_from_running_loop_returns_correct_receipt(self):
         """Receipt fields survive the thread-pool round-trip intact."""
         gw = _FakeX402Gateway()
 
-        async def call_sync_inside_loop() -> X402Receipt:
-            return gw.execute_x402(
-                "https://paid-api.example.com", 499, "PaidAPI", "data"
+        async def call_sync_inside_loop() -> X402Result:
+            return gw.execute(
+                499, "PaidAPI", "data", url="https://paid-api.example.com"
             )
 
         result = asyncio.run(call_sync_inside_loop())
@@ -255,14 +257,14 @@ class TestX402GatewaySyncDispatch:
         assert result.gateway_ref == "0xfakehash"
 
     def test_async_method_available(self):
-        """execute_x402_async() is directly awaitable for fully-async callers."""
+        """execute_async() is directly awaitable for fully-async callers."""
         gw = _FakeX402Gateway()
 
         async def run():
-            return await gw.execute_x402_async(
-                "https://api.example.com", 50, "vendor", "memo"
+            return await gw.execute_async(
+                50, "vendor", "memo", url="https://api.example.com"
             )
 
         result = asyncio.run(run())
-        assert isinstance(result, X402Receipt)
+        assert isinstance(result, X402Result)
         assert result.amount_cents == 50

--- a/uv.lock
+++ b/uv.lock
@@ -3202,7 +3202,7 @@ wheels = [
 
 [[package]]
 name = "paygraph"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Unify card and x402 gateways under a single `BaseGateway` ABC with a common `execute()` / `execute_async()` / `revoke()` interface
- New `SpendResult` type hierarchy (`CardResult`, `X402Result`) replaces `VirtualCard` and `X402Receipt`. Old names kept as deprecated aliases for now
- `AgentWallet` now takes a `gateways: dict[str, BaseGateway]` instead of separate `gateway` + `x402_gateway` params. All gateways share one `PolicyEngine` which fixes the budget circumvention issue where separate wallets had independent budget tracking
- Pulled the duplicated orchestration logic out of `request_spend` / `request_x402` / `request_x402_async` into a shared                    
`_execute_with_policy()` method
- Added `test_unified_budget.py` to prove card and x402 spends draw from the same daily budget

## Breaking changes

- `execute_spend()` renamed to `execute()` on all gateways
- `execute_x402()` / `execute_x402_async()` renamed to `execute()` / `execute_async()`
- `AgentWallet(gateway=..., x402_gateway=...)` becomes `AgentWallet(gateways=...)`

## Test plan

- All 133 existing tests pass with the updated interfaces
- New unified budget tests confirm cross-gateway overspend is correctly denied
- Ruff lint clean

Closes #6