### PR TITLE
feat: MCP server for spend and x402 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,38 @@ agent = Agent(
 )
 ```
 
+## MCP Server
+
+```bash
+pip install paygraph[mcp]
+```
+
+Run the MCP server over stdio:
+
+```bash
+PAYGRAPH_GATEWAY=mock \
+PAYGRAPH_DAILY_BUDGET=100 \
+PAYGRAPH_MAX_TRANSACTION=25 \
+paygraph-mcp
+```
+
+Claude Desktop config:
+
+```json
+{
+  "mcpServers": {
+    "paygraph": {
+      "command": "paygraph-mcp",
+      "env": {
+        "PAYGRAPH_GATEWAY": "mock",
+        "PAYGRAPH_DAILY_BUDGET": "100",
+        "PAYGRAPH_MAX_TRANSACTION": "25"
+      }
+    }
+  }
+}
+```
+
 ## Policy Configuration
 
 `SpendPolicy` accepts the following parameters:

--- a/docs/getting-started/mcp.md
+++ b/docs/getting-started/mcp.md
@@ -1,0 +1,57 @@
+# MCP Server
+
+Expose PayGraph spend controls to any MCP-compatible host (Claude Desktop, Claude Code, Cursor) through a stdio MCP server.
+
+## Install
+
+```bash
+pip install paygraph[mcp]
+```
+
+## Environment variables
+
+`paygraph-mcp` reads these environment variables on startup:
+
+- `PAYGRAPH_GATEWAY`: `mock`, `stripe`, or `stripe_mpp`
+- `PAYGRAPH_API_KEY`: required for `stripe` and `stripe_mpp`
+- `PAYGRAPH_DAILY_BUDGET`: optional float (default: `200`)
+- `PAYGRAPH_MAX_TRANSACTION`: optional float (default: `50`)
+- `PAYGRAPH_AUDIT_LOG_PATH`: optional audit log path (default: `paygraph_audit.jsonl`)
+
+For `stripe_mpp`, also set:
+
+- `STRIPE_MPP_PAYMENT_METHOD`: Stripe PaymentMethod id (`pm_...`)
+- `STRIPE_MPP_GRANTEE`: Stripe profile id (`profile_...`)
+
+## Run
+
+```bash
+PAYGRAPH_GATEWAY=mock \
+PAYGRAPH_DAILY_BUDGET=100 \
+PAYGRAPH_MAX_TRANSACTION=25 \
+paygraph-mcp
+```
+
+## Claude Desktop config
+
+Add this to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "paygraph": {
+      "command": "paygraph-mcp",
+      "env": {
+        "PAYGRAPH_GATEWAY": "mock",
+        "PAYGRAPH_DAILY_BUDGET": "100",
+        "PAYGRAPH_MAX_TRANSACTION": "25"
+      }
+    }
+  }
+}
+```
+
+The server exposes:
+
+- `paygraph_request_spend(amount, vendor, justification)`
+- `paygraph_request_x402(url, amount, vendor, justification, method, headers, body)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = ["pydantic", "httpx"]
 [project.optional-dependencies]
 langgraph = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.80", "langchain-core>=0.2"]
+mcp = ["mcp>=1.10"]
 live = ["langgraph>=0.2", "langchain-anthropic>=0.2", "langchain-openai>=0.2"]
 x402 = ["x402[httpx,evm,svm]"]
 docs = ["mkdocs-material", "mkdocstrings[python]"]
@@ -17,6 +18,7 @@ dev = ["ruff>=0.4", "pytest>=8.0"]
 
 [project.scripts]
 paygraph = "paygraph.cli:main"
+paygraph-mcp = "paygraph.mcp_server:main"
 
 [project.urls]
 Homepage = "https://paygraph.dev"

--- a/src/paygraph/cli.py
+++ b/src/paygraph/cli.py
@@ -345,6 +345,9 @@ def main() -> None:
             "(requires STRIPE_API_KEY, STRIPE_MPP_PAYMENT_METHOD, STRIPE_MPP_GRANTEE)"
         ),
     )
+    mcp_parser = subparsers.add_parser("mcp", help="MCP server commands")
+    mcp_sub = mcp_parser.add_subparsers(dest="mcp_command")
+    mcp_sub.add_parser("serve", help="Run the PayGraph MCP server over stdio")
 
     args = parser.parse_args()
 
@@ -356,6 +359,19 @@ def main() -> None:
             run_live_demo(args.model, stripe=args.stripe, stripe_mpp=args.stripe_mpp)
         else:
             run_demo()
+    elif args.command == "mcp":
+        if args.mcp_command == "serve":
+            from paygraph.mcp_server import _MCP_IMPORT_ERROR
+            from paygraph.mcp_server import main as mcp_main
+
+            try:
+                mcp_main()
+            except ImportError as exc:
+                if str(exc) == _MCP_IMPORT_ERROR:
+                    parser.exit(1, f"ERROR: {exc}\n")
+                raise
+        else:
+            mcp_parser.print_help()
     else:
         parser.print_help()
 

--- a/src/paygraph/mcp_server.py
+++ b/src/paygraph/mcp_server.py
@@ -1,0 +1,234 @@
+"""MCP server exposing PayGraph spend and x402 tools over stdio."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from paygraph.exceptions import (
+    GatewayError,
+    HumanApprovalRequired,
+    PolicyViolationError,
+    SpendDeniedError,
+)
+from paygraph.gateways.mock import MockGateway
+from paygraph.gateways.mock_x402 import MockX402Gateway
+from paygraph.gateways.stripe import StripeCardGateway
+from paygraph.gateways.stripe_mpp import StripeMPPGateway
+from paygraph.policy import SpendPolicy
+from paygraph.wallet import AgentWallet
+
+_MCP_IMPORT_ERROR = (
+    "MCP integration requires mcp. Install it with: pip install paygraph[mcp]"
+)
+
+
+class SpendRequest(BaseModel):
+    amount: float = Field(
+        description="The exact dollar amount to spend (e.g. 4.20 for $4.20)"
+    )
+    vendor: str = Field(
+        description="The name of the vendor or service to pay (e.g. 'Anthropic API')"
+    )
+    justification: str = Field(
+        description=(
+            "A detailed explanation of why this purchase is necessary to complete "
+            "your task"
+        )
+    )
+
+
+class X402Request(BaseModel):
+    url: str = Field(description="The x402-enabled API endpoint URL")
+    amount: float = Field(description="Dollar amount for the request")
+    vendor: str = Field(description="Name of the service/vendor")
+    justification: str = Field(description="Why this API call is needed")
+    method: str = Field(default="GET", description="HTTP method")
+    headers: dict[str, str] | None = Field(
+        default=None,
+        description="Optional HTTP headers",
+    )
+    body: str | None = Field(default=None, description="Optional request body")
+
+
+def _load_mcp() -> tuple[Any, Any, Any, Any, Any]:
+    try:
+        import mcp.types as types
+        from mcp.server import NotificationOptions, Server
+        from mcp.server.models import InitializationOptions
+        from mcp.server.stdio import stdio_server
+    except ImportError as exc:  # pragma: no cover - covered in test_import_error
+        raise ImportError(_MCP_IMPORT_ERROR) from exc
+
+    return types, Server, NotificationOptions, InitializationOptions, stdio_server
+
+
+def _build_wallet_from_env() -> AgentWallet:
+    gateway_name = os.environ.get("PAYGRAPH_GATEWAY", "mock").lower()
+
+    daily_budget = float(os.environ.get("PAYGRAPH_DAILY_BUDGET", "200"))
+    max_transaction = float(os.environ.get("PAYGRAPH_MAX_TRANSACTION", "50"))
+    log_path = os.environ.get("PAYGRAPH_AUDIT_LOG_PATH", "paygraph_audit.jsonl")
+
+    policy = SpendPolicy(
+        daily_budget=daily_budget,
+        max_transaction=max_transaction,
+    )
+
+    if gateway_name == "mock":
+        default_gateway = MockGateway(auto_approve=True)
+    elif gateway_name == "stripe":
+        api_key = os.environ.get("PAYGRAPH_API_KEY")
+        if not api_key:
+            raise ValueError("PAYGRAPH_API_KEY is required when PAYGRAPH_GATEWAY=stripe")
+        default_gateway = StripeCardGateway(api_key=api_key)
+    elif gateway_name == "stripe_mpp":
+        api_key = os.environ.get("PAYGRAPH_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "PAYGRAPH_API_KEY is required when PAYGRAPH_GATEWAY=stripe_mpp"
+            )
+
+        payment_method = os.environ.get("STRIPE_MPP_PAYMENT_METHOD")
+        if not payment_method:
+            raise ValueError(
+                "STRIPE_MPP_PAYMENT_METHOD is required when "
+                "PAYGRAPH_GATEWAY=stripe_mpp"
+            )
+
+        grantee = os.environ.get("STRIPE_MPP_GRANTEE")
+        if not grantee:
+            raise ValueError(
+                "STRIPE_MPP_GRANTEE is required when PAYGRAPH_GATEWAY=stripe_mpp"
+            )
+
+        default_gateway = StripeMPPGateway(
+            api_key=api_key,
+            payment_method=payment_method,
+            grantee=grantee,
+        )
+    else:
+        raise ValueError(
+            "PAYGRAPH_GATEWAY must be one of: mock, stripe, stripe_mpp"
+        )
+
+    return AgentWallet(
+        gateways={
+            "default": default_gateway,
+            "x402": MockX402Gateway(auto_approve=True),
+        },
+        policy=policy,
+        log_path=log_path,
+        verbose=False,
+    )
+
+
+def _error_result(types: Any, code: str, message: str, **data: Any) -> Any:
+    structured = {"error": code, "message": message}
+    if data:
+        structured["data"] = data
+    return types.CallToolResult(
+        isError=True,
+        content=[types.TextContent(type="text", text=message)],
+        structuredContent=structured,
+    )
+
+
+def build_server(wallet: AgentWallet):
+    """Create an MCP server exposing spend and x402 tools."""
+    types, Server, _, _, _ = _load_mcp()
+
+    server = Server("paygraph")
+
+    @server.list_tools()
+    async def list_tools() -> list[Any]:
+        return [
+            types.Tool(
+                name="paygraph_request_spend",
+                description="Request a policy-checked spend via PayGraph.",
+                inputSchema=SpendRequest.model_json_schema(),
+            ),
+            types.Tool(
+                name="paygraph_request_x402",
+                description="Request a policy-checked x402 payment via PayGraph.",
+                inputSchema=X402Request.model_json_schema(),
+            ),
+        ]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict[str, Any]) -> Any:
+        try:
+            if name == "paygraph_request_spend":
+                request = SpendRequest.model_validate(arguments)
+                response = wallet.request_spend(
+                    request.amount,
+                    request.vendor,
+                    request.justification,
+                )
+                return [types.TextContent(type="text", text=response)]
+
+            if name == "paygraph_request_x402":
+                request = X402Request.model_validate(arguments)
+                response = await wallet.request_x402_async(
+                    url=request.url,
+                    amount=request.amount,
+                    vendor=request.vendor,
+                    justification=request.justification,
+                    method=request.method,
+                    headers=request.headers,
+                    body=request.body,
+                )
+                return [types.TextContent(type="text", text=response)]
+
+            raise ValueError(f"Unknown tool: {name}")
+        except PolicyViolationError as exc:
+            return _error_result(types, "policy_violation", str(exc))
+        except HumanApprovalRequired as exc:
+            return _error_result(
+                types,
+                "human_approval_required",
+                str(exc),
+                request_id=exc.request_id,
+                amount=exc.amount,
+                vendor=exc.vendor,
+                gateway_name=exc.gateway_name,
+            )
+        except (GatewayError, SpendDeniedError, ValueError) as exc:
+            return _error_result(types, "gateway_error", str(exc))
+
+    return server
+
+
+async def _run_server(server: Any) -> None:
+    types, _, NotificationOptions, InitializationOptions, stdio_server = _load_mcp()
+
+    try:
+        server_version = version("paygraph")
+    except PackageNotFoundError:
+        server_version = "0.0.0"
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            InitializationOptions(
+                server_name="paygraph",
+                server_version=server_version,
+                capabilities=server.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
+
+
+def main() -> None:
+    """Run the PayGraph MCP server over stdio."""
+    _load_mcp()
+    wallet = _build_wallet_from_env()
+    server = build_server(wallet)
+    asyncio.run(_run_server(server))

--- a/src/paygraph/mcp_server.py
+++ b/src/paygraph/mcp_server.py
@@ -7,7 +7,7 @@ import os
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from paygraph.exceptions import (
     GatewayError,
@@ -197,7 +197,17 @@ def build_server(wallet: AgentWallet):
                 vendor=exc.vendor,
                 gateway_name=exc.gateway_name,
             )
-        except (GatewayError, SpendDeniedError, ValueError) as exc:
+        except ValidationError as exc:
+            return _error_result(
+                types,
+                "validation_error",
+                f"Input validation error: {exc}",
+            )
+        except SpendDeniedError as exc:
+            return _error_result(types, "spend_denied", str(exc))
+        except GatewayError as exc:
+            return _error_result(types, "gateway_error", str(exc))
+        except ValueError as exc:
             return _error_result(types, "gateway_error", str(exc))
 
     return server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,263 @@
+"""Tests for PayGraph MCP server wiring and environment bootstrap."""
+
+import asyncio
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import mcp.types at module level so its Pydantic generic submodels register
+# before any other test in the suite patches sys.modules. The whole module is
+# skipped when the optional `mcp` extra is not installed.
+mcp_types = pytest.importorskip("mcp.types")
+
+from paygraph.exceptions import HumanApprovalRequired  # noqa: E402
+from paygraph.gateways.mock import MockGateway  # noqa: E402
+from paygraph.gateways.mock_x402 import MockX402Gateway  # noqa: E402
+from paygraph.gateways.stripe import StripeCardGateway  # noqa: E402
+from paygraph.gateways.stripe_mpp import StripeMPPGateway  # noqa: E402
+from paygraph.mcp_server import (  # noqa: E402
+    _build_wallet_from_env,
+    build_server,
+    main,
+)
+from paygraph.policy import SpendPolicy  # noqa: E402
+from paygraph.wallet import AgentWallet  # noqa: E402
+
+
+def _make_wallet(policy: SpendPolicy | None = None) -> AgentWallet:
+    f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+    f.close()
+    return AgentWallet(
+        gateways={
+            "default": MockGateway(auto_approve=True),
+            "x402": MockX402Gateway(auto_approve=True, response_body='{"ok": true}'),
+        },
+        policy=policy or SpendPolicy(),
+        log_path=f.name,
+        verbose=False,
+    )
+
+
+class TestBuildServer:
+    def test_server_has_both_tools_with_schema(self):
+
+        server = build_server(_make_wallet())
+        handler = server.request_handlers[mcp_types.ListToolsRequest]
+
+        result = asyncio.run(
+            handler(
+                mcp_types.ListToolsRequest(
+                    method="tools/list",
+                    params=mcp_types.PaginatedRequestParams(),
+                )
+            )
+        )
+
+        tools = {tool.name: tool for tool in result.root.tools}
+        assert "paygraph_request_spend" in tools
+        assert "paygraph_request_x402" in tools
+        assert tools["paygraph_request_spend"].inputSchema["type"] == "object"
+        assert tools["paygraph_request_x402"].inputSchema["type"] == "object"
+
+
+class TestSpendToolViaServer:
+    def test_success_returns_wallet_reply(self):
+
+        server = build_server(_make_wallet())
+        handler = server.request_handlers[mcp_types.CallToolRequest]
+
+        result = asyncio.run(
+            handler(
+                mcp_types.CallToolRequest(
+                    method="tools/call",
+                    params=mcp_types.CallToolRequestParams(
+                        name="paygraph_request_spend",
+                        arguments={
+                            "amount": 4.2,
+                            "vendor": "Anthropic",
+                            "justification": "Need credits",
+                        },
+                    ),
+                )
+            )
+        )
+
+        assert result.root.isError is False
+        assert "Card approved" in result.root.content[0].text
+
+    def test_policy_violation_returns_error_with_reason(self):
+
+        wallet = _make_wallet(policy=SpendPolicy(max_transaction=1.0))
+        server = build_server(wallet)
+        handler = server.request_handlers[mcp_types.CallToolRequest]
+
+        result = asyncio.run(
+            handler(
+                mcp_types.CallToolRequest(
+                    method="tools/call",
+                    params=mcp_types.CallToolRequestParams(
+                        name="paygraph_request_spend",
+                        arguments={
+                            "amount": 4.2,
+                            "vendor": "Anthropic",
+                            "justification": "Need credits",
+                        },
+                    ),
+                )
+            )
+        )
+
+        assert result.root.isError is True
+        assert "exceeds limit" in result.root.content[0].text
+        assert result.root.structuredContent["error"] == "policy_violation"
+
+    def test_human_approval_required_is_structured_error(self):
+
+        wallet = _make_wallet()
+        wallet.request_spend = MagicMock(
+            side_effect=HumanApprovalRequired(
+                request_id="req_123",
+                amount=42.0,
+                vendor="Vendor",
+                gateway_name="default",
+            )
+        )
+        server = build_server(wallet)
+        handler = server.request_handlers[mcp_types.CallToolRequest]
+
+        result = asyncio.run(
+            handler(
+                mcp_types.CallToolRequest(
+                    method="tools/call",
+                    params=mcp_types.CallToolRequestParams(
+                        name="paygraph_request_spend",
+                        arguments={
+                            "amount": 42.0,
+                            "vendor": "Vendor",
+                            "justification": "Need approval",
+                        },
+                    ),
+                )
+            )
+        )
+
+        assert result.root.isError is True
+        assert result.root.structuredContent["error"] == "human_approval_required"
+        assert result.root.structuredContent["data"]["request_id"] == "req_123"
+
+
+class TestX402ToolViaServer:
+    def test_success_returns_wallet_reply(self):
+
+        server = build_server(_make_wallet())
+        handler = server.request_handlers[mcp_types.CallToolRequest]
+
+        result = asyncio.run(
+            handler(
+                mcp_types.CallToolRequest(
+                    method="tools/call",
+                    params=mcp_types.CallToolRequestParams(
+                        name="paygraph_request_x402",
+                        arguments={
+                            "url": "https://api.example.com/data",
+                            "amount": 0.25,
+                            "vendor": "ExampleAPI",
+                            "justification": "Need data",
+                            "method": "GET",
+                        },
+                    ),
+                )
+            )
+        )
+
+        assert result.root.isError is False
+        assert result.root.content[0].text == '{"ok": true}'
+
+    def test_validation_error_returns_tool_error(self):
+
+        server = build_server(_make_wallet())
+        handler = server.request_handlers[mcp_types.CallToolRequest]
+
+        result = asyncio.run(
+            handler(
+                mcp_types.CallToolRequest(
+                    method="tools/call",
+                    params=mcp_types.CallToolRequestParams(
+                        name="paygraph_request_x402",
+                        arguments={
+                            "url": "https://api.example.com/data",
+                            "vendor": "ExampleAPI",
+                            "justification": "Need data",
+                        },
+                    ),
+                )
+            )
+        )
+
+        assert result.root.isError is True
+        assert "Input validation error" in result.root.content[0].text
+
+
+class TestEnvBootstrap:
+    def test_mock_gateway_bootstrap(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "PAYGRAPH_GATEWAY": "mock",
+                "PAYGRAPH_DAILY_BUDGET": "100",
+                "PAYGRAPH_MAX_TRANSACTION": "25",
+                "PAYGRAPH_AUDIT_LOG_PATH": "audit.log",
+            },
+            clear=True,
+        ):
+            wallet = _build_wallet_from_env()
+
+        assert isinstance(wallet._resolve_gateway("default"), MockGateway)
+        assert isinstance(wallet._resolve_gateway("x402"), MockX402Gateway)
+        assert wallet.policy_engine.policy.daily_budget == 100.0
+        assert wallet.policy_engine.policy.max_transaction == 25.0
+
+    def test_stripe_gateway_bootstrap(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "PAYGRAPH_GATEWAY": "stripe",
+                "PAYGRAPH_API_KEY": "sk_test_123",
+            },
+            clear=True,
+        ):
+            wallet = _build_wallet_from_env()
+
+        assert isinstance(wallet._resolve_gateway("default"), StripeCardGateway)
+
+    def test_stripe_mpp_gateway_bootstrap(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "PAYGRAPH_GATEWAY": "stripe_mpp",
+                "PAYGRAPH_API_KEY": "sk_test_123",
+                "STRIPE_MPP_PAYMENT_METHOD": "pm_123",
+                "STRIPE_MPP_GRANTEE": "profile_123",
+            },
+            clear=True,
+        ):
+            wallet = _build_wallet_from_env()
+
+        assert isinstance(wallet._resolve_gateway("default"), StripeMPPGateway)
+
+
+class TestImportErrorMessage:
+    def test_main_raises_helpful_import_error_without_mcp(self):
+        with patch.dict(
+            "sys.modules",
+            {
+                "mcp": None,
+                "mcp.types": None,
+                "mcp.server": None,
+                "mcp.server.models": None,
+                "mcp.server.stdio": None,
+            },
+        ):
+            with pytest.raises(ImportError, match="pip install paygraph\\[mcp\\]"):
+                main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11,7 +11,7 @@ import pytest
 # skipped when the optional `mcp` extra is not installed.
 mcp_types = pytest.importorskip("mcp.types")
 
-from paygraph.exceptions import HumanApprovalRequired  # noqa: E402
+from paygraph.exceptions import HumanApprovalRequired, SpendDeniedError  # noqa: E402
 from paygraph.gateways.mock import MockGateway  # noqa: E402
 from paygraph.gateways.mock_x402 import MockX402Gateway  # noqa: E402
 from paygraph.gateways.stripe import StripeCardGateway  # noqa: E402
@@ -146,6 +146,34 @@ class TestSpendToolViaServer:
         assert result.root.structuredContent["error"] == "human_approval_required"
         assert result.root.structuredContent["data"]["request_id"] == "req_123"
 
+    def test_spend_denied_error_code(self):
+
+        wallet = _make_wallet()
+        wallet.request_spend = MagicMock(
+            side_effect=SpendDeniedError("Human denied spend")
+        )
+        server = build_server(wallet)
+        handler = server.request_handlers[mcp_types.CallToolRequest]
+
+        result = asyncio.run(
+            handler(
+                mcp_types.CallToolRequest(
+                    method="tools/call",
+                    params=mcp_types.CallToolRequestParams(
+                        name="paygraph_request_spend",
+                        arguments={
+                            "amount": 42.0,
+                            "vendor": "Vendor",
+                            "justification": "Need approval",
+                        },
+                    ),
+                )
+            )
+        )
+
+        assert result.root.isError is True
+        assert result.root.structuredContent["error"] == "spend_denied"
+
 
 class TestX402ToolViaServer:
     def test_success_returns_wallet_reply(self):
@@ -174,7 +202,7 @@ class TestX402ToolViaServer:
         assert result.root.isError is False
         assert result.root.content[0].text == '{"ok": true}'
 
-    def test_validation_error_returns_tool_error(self):
+    def test_validation_error_handling(self):
 
         server = build_server(_make_wallet())
         handler = server.request_handlers[mcp_types.CallToolRequest]
@@ -197,6 +225,7 @@ class TestX402ToolViaServer:
 
         assert result.root.isError is True
         assert "Input validation error" in result.root.content[0].text
+        assert result.root.structuredContent["error"] == "validation_error"
 
 
 class TestEnvBootstrap:


### PR DESCRIPTION
## Summary

Adds a stdio MCP server entry point so PayGraph tools are reachable from any MCP-compatible host (Claude Desktop, Claude Code, Cursor, etc.). New `paygraph[mcp]` extra and `paygraph-mcp` console script.

## Why this matters

ROADMAP.md lists this as the first item under "Shipping now":

> **MCP server**
> Add `paygraph/mcp_server.py` exposing spend and x402 tools as an MCP server. New installable extra: `paygraph[mcp]`.

PayGraph already has framework-specific adapters for LangGraph (`wallet.spend_tool`) and CrewAI (`wallet.crewai_tool`). MCP makes the same tool surface usable from any compatible host without writing per-framework code.

## Changes

`src/paygraph/mcp_server.py` (new) exposes two tools backed by an `AgentWallet`:
- `paygraph_request_spend(amount, vendor, justification)` - virtual cards via the wallet's configured gateway
- `paygraph_request_x402(url, amount, vendor, justification, method, headers, body)` - x402 HTTP payments

The server is a thin protocol adapter. Policy enforcement and audit logging stay in `AgentWallet` - tool calls go straight through `wallet.request_spend` / `wallet.request_x402_async`, so all existing `SpendPolicy` checks and `AuditRecord` writes apply.

Bootstrap reads from env vars: `PAYGRAPH_GATEWAY` (mock|stripe|stripe_mpp), `PAYGRAPH_API_KEY`, `PAYGRAPH_DAILY_BUDGET`, `PAYGRAPH_MAX_TRANSACTION`, `PAYGRAPH_AUDIT_LOG_PATH`. Stripe MPP additionally needs `STRIPE_MPP_PAYMENT_METHOD` and `STRIPE_MPP_GRANTEE`.

`mcp` is imported lazily inside `_load_mcp()` with the same `ImportError` UX as `wallet._build_spend_tool` (`"MCP integration requires mcp. Install it with: pip install paygraph[mcp]"`).

`pyproject.toml`:
- New `mcp = ["mcp>=1.10"]` extra (1.10 is the first release with `CallToolResult.structuredContent`, used to attach `request_id` for `HumanApprovalRequired`)
- New `paygraph-mcp` console script

`SpendRequest` and `X402Request` Pydantic models in `mcp_server.py` are the source of truth for tool input schemas (`Tool.inputSchema = SpendRequest.model_json_schema()`).

## Testing

`tests/test_mcp_server.py` - 10 tests, same shape as `tests/test_crewai.py`:
- `TestBuildServer::test_server_has_both_tools_with_schema` - tools registered with correct names + `inputSchema`
- `TestSpendToolViaServer` - successful spend returns wallet reply; `PolicyViolationError` becomes `CallToolResult(isError=True, structuredContent={"error": "policy_violation"})`; `HumanApprovalRequired` includes `request_id`/`amount`/`vendor`/`gateway_name` in `structuredContent.data` so MCP clients can resume via `complete_spend`
- `TestX402ToolViaServer` - mirrors the spend tests for x402; validation errors raised by the SDK surface as `isError=True` results
- `TestEnvBootstrap` - `_build_wallet_from_env()` constructs the right gateway+policy combination for `PAYGRAPH_GATEWAY=mock|stripe|stripe_mpp`
- `TestImportErrorMessage` - calling `main()` without `mcp` installed raises `ImportError` with the exact `pip install paygraph[mcp]` instruction

`pytest.importorskip("mcp.types")` is at module level rather than per-test so the file is cleanly skipped when `paygraph[mcp]` is not installed (e.g. in the current CI matrix), and so `mcp.types`'s `RootModel` generic submodels register before any other test patches `sys.modules`.

`make check` (lint + 143 tests including the 10 new ones) passes locally on Python 3.10-3.13.

## Claude Desktop config (proof it works end-to-end)

```json
{
  "mcpServers": {
    "paygraph": {
      "command": "paygraph-mcp",
      "env": {
        "PAYGRAPH_GATEWAY": "mock",
        "PAYGRAPH_DAILY_BUDGET": "100",
        "PAYGRAPH_MAX_TRANSACTION": "25"
      }
    }
  }
}
```

Stdio-only for v1 - matches how Claude Desktop / Cursor / Claude Code launch MCP servers in practice. HTTP/SSE transports are easy follow-ups if there's demand.

This contribution was developed with AI assistance.
