### PR TITLE
feat(slack): TTL/timeout for pending approval requests (closes #23)

### DIFF
--- a/src/paygraph/gateways/slack.py
+++ b/src/paygraph/gateways/slack.py
@@ -1,9 +1,12 @@
 import secrets
+import time
 
 import httpx
 
 from paygraph.exceptions import GatewayError, HumanApprovalRequired, SpendDeniedError
 from paygraph.gateways.base import BaseGateway, CardResult, SpendResult
+
+DEFAULT_PENDING_TTL_SECONDS = 24 * 60 * 60
 
 
 class SlackApprovalGateway(BaseGateway):
@@ -39,15 +42,25 @@ class SlackApprovalGateway(BaseGateway):
             )
     """
 
-    def __init__(self, webhook_url: str, inner_gateway: BaseGateway) -> None:
+    def __init__(
+        self,
+        webhook_url: str,
+        inner_gateway: BaseGateway,
+        pending_ttl_seconds: int | None = DEFAULT_PENDING_TTL_SECONDS,
+    ) -> None:
         """Initialise the Slack approval gateway.
 
         Args:
             webhook_url: Slack incoming webhook URL to post approval requests to.
             inner_gateway: Gateway used to execute the spend once approved.
+            pending_ttl_seconds: How long (in seconds) a pending approval request
+                stays valid before auto-denying. Defaults to 24h. Pass ``None``
+                to disable expiry (entries live forever — discouraged for
+                production use).
         """
         self.webhook_url = webhook_url
         self.inner_gateway = inner_gateway
+        self.pending_ttl_seconds = pending_ttl_seconds
         self._pending: dict[str, dict] = {}
 
     def request_approval(
@@ -97,8 +110,27 @@ class SlackApprovalGateway(BaseGateway):
             "vendor": vendor,
             "memo": memo,
             "justification": justification,
+            "created_at": time.monotonic(),
         }
         raise HumanApprovalRequired(request_id, amount_dollars, vendor)
+
+    def _is_expired(self, pending: dict) -> bool:
+        if self.pending_ttl_seconds is None:
+            return False
+        return time.monotonic() - pending["created_at"] > self.pending_ttl_seconds
+
+    def purge_expired(self) -> int:
+        """Drop all pending requests older than ``pending_ttl_seconds``.
+
+        Returns:
+            The number of requests purged.
+        """
+        if self.pending_ttl_seconds is None:
+            return 0
+        expired = [rid for rid, p in self._pending.items() if self._is_expired(p)]
+        for rid in expired:
+            del self._pending[rid]
+        return len(expired)
 
     def execute(
         self, amount_cents: int, vendor: str, memo: str, **kwargs
@@ -127,10 +159,16 @@ class SlackApprovalGateway(BaseGateway):
             A ``CardResult`` from the inner gateway if approved.
 
         Raises:
-            SpendDeniedError: If ``approved`` is ``False``.
+            SpendDeniedError: If ``approved`` is ``False`` or if the request
+                has expired past ``pending_ttl_seconds``.
             KeyError: If ``request_id`` is unknown or already completed.
         """
         pending = self._pending.pop(request_id)
+        if self._is_expired(pending):
+            raise SpendDeniedError(
+                f"Approval timed out for spend of "
+                f"${pending['amount_cents'] / 100:.2f} for {pending['vendor']}"
+            )
         if not approved:
             raise SpendDeniedError(
                 f"Human denied spend of ${pending['amount_cents'] / 100:.2f} "
@@ -144,7 +182,9 @@ class SlackApprovalGateway(BaseGateway):
         """Return a pending request's metadata without removing it.
 
         Used by ``AgentWallet.complete_spend()`` to retrieve vendor/justification
-        for audit logging before calling ``complete_spend()``.
+        for audit logging before calling ``complete_spend()``. Expired entries
+        are still returned so the caller can write a denial audit record;
+        ``complete_spend()`` will then raise ``SpendDeniedError``.
 
         Raises:
             KeyError: If ``request_id`` is unknown.

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -382,7 +382,7 @@ class AgentWallet:
 
         try:
             card = gw.complete_spend(request_id, approved)
-        except SpendDeniedError:
+        except SpendDeniedError as e:
             self._audit.log(
                 AuditRecord.now(
                     agent_id=self.agent_id,
@@ -390,7 +390,7 @@ class AgentWallet:
                     vendor=vendor,
                     justification=justification,
                     policy_result="denied",
-                    denial_reason=f"Human denied spend of ${amount:.2f} for {vendor}",
+                    denial_reason=str(e),
                 )
             )
             raise

--- a/tests/test_slack_gateway.py
+++ b/tests/test_slack_gateway.py
@@ -337,3 +337,115 @@ class TestCompleteSpendUnknownRequestId:
         wallet, _ = _make_slack_wallet()
         with pytest.raises(PayGraphError):
             wallet.complete_spend("nonexistent_id", approved=True)
+
+
+# ---------------------------------------------------------------------------
+# TTL / expiry tests
+# ---------------------------------------------------------------------------
+
+
+class TestPendingTTL:
+    def test_default_ttl_is_24_hours(self):
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+        )
+        assert gateway.pending_ttl_seconds == 24 * 60 * 60
+
+    def test_expired_request_raises_spend_denied(self):
+        """complete_spend on an expired request raises SpendDeniedError with timeout reason."""
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+            pending_ttl_seconds=60,
+        )
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                gateway.request_approval(5000, "Anthropic", "need tokens")
+
+        # Backdate the entry so it appears stale
+        gateway._pending[exc_info.value.request_id]["created_at"] -= 120
+
+        with pytest.raises(SpendDeniedError, match="timed out"):
+            gateway.complete_spend(exc_info.value.request_id, approved=True)
+
+    def test_ttl_none_disables_expiry(self):
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+            pending_ttl_seconds=None,
+        )
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                gateway.request_approval(5000, "Anthropic", "need tokens")
+
+        # Even with a very old created_at, no expiry triggers
+        gateway._pending[exc_info.value.request_id]["created_at"] -= 10**9
+        card = gateway.complete_spend(exc_info.value.request_id, approved=True)
+        assert card.pan == "4111111111111111"
+
+    def test_purge_expired_drops_stale_entries(self):
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+            pending_ttl_seconds=60,
+        )
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as fresh:
+                gateway.request_approval(1000, "FreshVendor", "still valid")
+            with pytest.raises(HumanApprovalRequired) as stale:
+                gateway.request_approval(2000, "StaleVendor", "old entry")
+
+        gateway._pending[stale.value.request_id]["created_at"] -= 120
+
+        purged = gateway.purge_expired()
+        assert purged == 1
+        assert fresh.value.request_id in gateway._pending
+        assert stale.value.request_id not in gateway._pending
+
+    def test_purge_expired_noop_when_ttl_none(self):
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+            pending_ttl_seconds=None,
+        )
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired):
+                gateway.request_approval(1000, "Anthropic", "memo")
+        assert gateway.purge_expired() == 0
+        assert len(gateway._pending) == 1
+
+    def test_wallet_complete_spend_audits_timeout_with_real_metadata(self):
+        """When wallet.complete_spend hits an expired request, audit captures the timeout reason."""
+        gateway = SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/test",
+            inner_gateway=MockGateway(auto_approve=True),
+            pending_ttl_seconds=60,
+        )
+        f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+        f.close()
+        wallet = AgentWallet(
+            gateways=gateway,
+            policy=SpendPolicy(require_human_approval_above=20.0),
+            log_path=f.name,
+            verbose=False,
+        )
+
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet.request_spend(50.0, "Anthropic", "need tokens")
+
+        request_id = exc_info.value.request_id
+        gateway._pending[request_id]["created_at"] -= 120
+
+        with pytest.raises(SpendDeniedError, match="timed out"):
+            wallet.complete_spend(
+                request_id, approved=True, gateway=exc_info.value.gateway_name
+            )
+
+        records = _read_audit(f.name)
+        denied = next(r for r in records if r["policy_result"] == "denied")
+        assert denied["vendor"] == "Anthropic"
+        assert denied["justification"] == "need tokens"
+        assert denied["amount"] == 50.0
+        assert "timed out" in denied["denial_reason"]


### PR DESCRIPTION
Closes #23.

## What this does

`SlackApprovalGateway` now bounds the lifetime of pending approval requests so they can't accumulate forever in memory.

* **New `pending_ttl_seconds` constructor arg**: Default is `86400` (24h). Pass `None` to disable expiration.
* **Monotonic Timing**: Each pending entry records `created_at` using `time.monotonic()`, making it immune to system wall-clock changes.
* **Expiration Enforcement**: Calling `complete_spend()` on an expired request now raises `SpendDeniedError("Approval timed out for ...")`.
* **Proactive Cleanup**: Added a `purge_expired()` method for callers who want to sweep stale entries proactively.
* **Audit Preservation**: `AgentWallet.complete_spend()` now propagates the gateway's `SpendDeniedError` message into the audit record. This ensures the distinction between a **timeout** and a **human-initiated denial** is preserved in the audit trail.

## Out of scope

* **Pluggable durable backend (Redis/SQLite)**: The issue mentions this, but it involves a larger architectural shift (new dependencies and abstraction layers). I'm happy to follow up with this in a separate PR if desired.

## Test plan

- [x] **139 tests pass**: `uv run pytest tests/`
- [x] **Ruff clean**: `uv run ruff check src/ tests/`
- [x] **New `TestPendingTTL` class (6 tests)**:
    - Default TTL is 24h.
    - Expired request raises `SpendDeniedError` with "...timed out" messaging.
    - `pending_ttl_seconds=None` successfully disables expiry.
    - `purge_expired()` drops only stale entries.
    - `purge_expired()` is a no-op when TTL is disabled.
    - **E2E**: `wallet.complete_spend` correctly captures the timeout reason in the audit record with real vendor/justification data.