### PR TITLE
feat: add MCP server support with paygraph mcp serve command

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,106 @@
+# MCP Server
+
+PayGraph can run as an [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) server, allowing any MCP-compatible AI client to request virtual cards and check budget status.
+
+## Installation
+
+```bash
+pip install paygraph[mcp]
+```
+
+## Running the Server
+
+### Stdio transport (for Claude Desktop, Cursor)
+
+```bash
+paygraph mcp serve
+```
+
+### HTTP transport (for remote deployment)
+
+```bash
+paygraph mcp serve --transport http --port 8080
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--transport` | Transport protocol: `stdio` or `http` (default: `stdio`) |
+| `--port` | Port for HTTP transport (default: `8080`) |
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `mint_virtual_card` | Request a policy-checked virtual card for a purchase |
+| `check_budget_status` | Check remaining budget across all time periods |
+| `get_policy_info` | Get current spend policy configuration |
+
+### `mint_virtual_card`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `amount` | float | Dollar amount to spend (e.g. 4.20 for $4.20) |
+| `vendor` | string | Name of the vendor or service |
+| `justification` | string | Explanation of why this purchase is necessary |
+
+### `check_budget_status`
+
+No parameters. Returns a summary of daily spend, remaining budget, and any configured time-based limits (hourly, weekly, monthly).
+
+### `get_policy_info`
+
+No parameters. Returns the current policy settings including max transaction limit, daily budget, justification requirements, and vendor allow/block lists.
+
+## Claude Desktop Configuration
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "paygraph": {
+      "command": "paygraph",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+## Cursor Configuration
+
+Add to your Cursor MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "paygraph": {
+      "command": "paygraph",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+## Programmatic Usage
+
+You can also create an MCP server programmatically with a custom wallet:
+
+```python
+from paygraph import AgentWallet, SpendPolicy
+from paygraph.mcp_server import create_mcp_server
+from paygraph.gateways.mock import MockGateway
+
+wallet = AgentWallet(
+    gateway=MockGateway(auto_approve=True),
+    policy=SpendPolicy(
+        max_transaction=100.0,
+        daily_budget=500.0,
+        blocked_vendors=["doordash"],
+    ),
+)
+
+mcp = create_mcp_server(wallet=wallet)
+mcp.run(transport="stdio")
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ langgraph = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.80", "langchain-core>=0.2"]
 live = ["langgraph>=0.2", "langchain-anthropic>=0.2", "langchain-openai>=0.2"]
 x402 = ["x402[httpx,evm,svm]"]
+mcp = ["mcp>=1.0"]
 docs = ["mkdocs-material", "mkdocstrings[python]"]
 dev = ["ruff>=0.4", "pytest>=8.0"]
 

--- a/src/paygraph/__init__.py
+++ b/src/paygraph/__init__.py
@@ -42,3 +42,10 @@ __all__ = [
     "GatewayError",
     "HumanApprovalRequired",
 ]
+
+try:
+    from paygraph.mcp_server import create_mcp_server  # noqa: F401
+
+    __all__.append("create_mcp_server")
+except ImportError:
+    pass

--- a/src/paygraph/cli.py
+++ b/src/paygraph/cli.py
@@ -312,6 +312,25 @@ def run_live_demo(model: str, stripe: bool = False, stripe_mpp: bool = False) ->
     os.unlink(audit_path)
 
 
+def run_mcp_server(transport: str, port: int) -> None:
+    """Run the MCP server with the specified transport."""
+    try:
+        from paygraph.mcp_server import create_mcp_server
+    except ImportError:
+        print(
+            "ERROR: MCP server requires MCP extras.\n"
+            "Install with: pip install paygraph[mcp]"
+        )
+        raise SystemExit(1)
+
+    mcp = create_mcp_server()
+
+    if transport == "stdio":
+        mcp.run(transport="stdio")
+    else:
+        mcp.run(transport="streamable-http", port=port)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="paygraph",
@@ -346,6 +365,26 @@ def main() -> None:
         ),
     )
 
+    mcp_parser = subparsers.add_parser(
+        "mcp", help="Run PayGraph as an MCP server"
+    )
+    mcp_subparsers = mcp_parser.add_subparsers(dest="mcp_command")
+    serve_parser = mcp_subparsers.add_parser(
+        "serve", help="Start the MCP server"
+    )
+    serve_parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help="Transport protocol (default: stdio)",
+    )
+    serve_parser.add_argument(
+        "--port",
+        type=int,
+        default=8080,
+        help="Port for HTTP transport (default: 8080)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "demo":
@@ -356,6 +395,11 @@ def main() -> None:
             run_live_demo(args.model, stripe=args.stripe, stripe_mpp=args.stripe_mpp)
         else:
             run_demo()
+    elif args.command == "mcp":
+        if args.mcp_command == "serve":
+            run_mcp_server(args.transport, args.port)
+        else:
+            mcp_parser.print_help()
     else:
         parser.print_help()
 

--- a/src/paygraph/mcp_server.py
+++ b/src/paygraph/mcp_server.py
@@ -1,0 +1,122 @@
+"""MCP server exposing PayGraph spend governance tools.
+
+This module implements an MCP (Model Context Protocol) server that allows
+AI agents to request virtual cards and check budget status through the
+standardized MCP interface.
+
+Example:
+    Run the server with stdio transport::
+
+        paygraph mcp serve
+
+    Or with HTTP transport::
+
+        paygraph mcp serve --transport http --port 8080
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+from paygraph.exceptions import GatewayError, PolicyViolationError
+from paygraph.gateways.mock import MockGateway
+from paygraph.policy import SpendPolicy
+from paygraph.wallet import AgentWallet
+
+
+def create_mcp_server(
+    wallet: AgentWallet | None = None,
+    name: str = "paygraph",
+) -> FastMCP:
+    """Create an MCP server with PayGraph tools.
+
+    Args:
+        wallet: Pre-configured AgentWallet. If None, creates a default
+            wallet with MockGateway and standard policy.
+        name: Server name for MCP identification.
+
+    Returns:
+        Configured FastMCP server instance.
+    """
+    mcp = FastMCP(name)
+
+    if wallet is None:
+        wallet = AgentWallet(
+            gateway=MockGateway(auto_approve=True),
+            policy=SpendPolicy(),
+        )
+
+    @mcp.tool()
+    def mint_virtual_card(
+        amount: float,
+        vendor: str,
+        justification: str,
+    ) -> str:
+        """Request a virtual card for a purchase.
+
+        Evaluates the spend against the configured policy, then mints
+        a virtual card if approved.
+
+        Args:
+            amount: Dollar amount to spend (e.g. 4.20 for $4.20).
+            vendor: Name of the vendor or service.
+            justification: Explanation of why this purchase is necessary.
+
+        Returns:
+            Card details (PAN, CVV, expiry) or error message.
+        """
+        try:
+            result = wallet.request_spend(amount, vendor, justification)
+            return result
+        except PolicyViolationError as e:
+            return f"Policy denied: {e}"
+        except GatewayError as e:
+            return f"Gateway error: {e}"
+
+    @mcp.tool()
+    def check_budget_status() -> str:
+        """Check remaining budget across all time periods.
+
+        Returns:
+            Summary of daily spend and remaining budget.
+        """
+        engine = wallet.policy_engine
+        policy = engine.policy
+        daily_spent = engine._daily_spend
+        daily_remaining = policy.daily_budget - daily_spent
+
+        lines = [
+            f"Daily: ${daily_spent:.2f} spent / ${policy.daily_budget:.2f} limit "
+            f"(${daily_remaining:.2f} remaining)",
+            f"Max transaction: ${policy.max_transaction:.2f}",
+        ]
+
+        if policy.hourly_budget is not None:
+            lines.append(f"Hourly limit: ${policy.hourly_budget:.2f}")
+        if policy.weekly_budget is not None:
+            lines.append(f"Weekly limit: ${policy.weekly_budget:.2f}")
+        if policy.monthly_budget is not None:
+            lines.append(f"Monthly limit: ${policy.monthly_budget:.2f}")
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    def get_policy_info() -> str:
+        """Get current spend policy configuration.
+
+        Returns:
+            Policy settings including limits and restrictions.
+        """
+        policy = wallet.policy_engine.policy
+        lines = [
+            f"Max transaction: ${policy.max_transaction:.2f}",
+            f"Daily budget: ${policy.daily_budget:.2f}",
+            f"Justification required: {policy.require_justification}",
+        ]
+
+        if policy.allowed_vendors:
+            lines.append(f"Allowed vendors: {', '.join(policy.allowed_vendors)}")
+        if policy.blocked_vendors:
+            lines.append(f"Blocked vendors: {', '.join(policy.blocked_vendors)}")
+
+        return "\n".join(lines)
+
+    return mcp

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,138 @@
+"""Tests for MCP server functionality."""
+
+import tempfile
+
+import pytest
+
+from paygraph.gateways.mock import MockGateway
+from paygraph.policy import SpendPolicy
+from paygraph.wallet import AgentWallet
+
+mcp_module = pytest.importorskip("mcp", reason="MCP extras not installed")
+
+
+def _make_server(policy=None, gateway=None):
+    """Create an MCP server with a temp audit file. Returns (server, wallet)."""
+    from paygraph.mcp_server import create_mcp_server
+
+    f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+    f.close()
+    wallet = AgentWallet(
+        gateway=gateway or MockGateway(auto_approve=True),
+        policy=policy or SpendPolicy(),
+        log_path=f.name,
+        verbose=False,
+    )
+    server = create_mcp_server(wallet=wallet)
+    return server, wallet
+
+
+class TestMCPServerCreation:
+    """Test MCP server initialization."""
+
+    def test_create_server_with_default_wallet(self):
+        from paygraph.mcp_server import create_mcp_server
+
+        server = create_mcp_server()
+        assert server is not None
+        assert server.name == "paygraph"
+
+    def test_create_server_with_custom_name(self):
+        from paygraph.mcp_server import create_mcp_server
+
+        server = create_mcp_server(name="custom-paygraph")
+        assert server.name == "custom-paygraph"
+
+    def test_create_server_with_custom_wallet(self):
+        from paygraph.mcp_server import create_mcp_server
+
+        wallet = AgentWallet(
+            gateway=MockGateway(auto_approve=True),
+            policy=SpendPolicy(max_transaction=100.0),
+            verbose=False,
+        )
+        server = create_mcp_server(wallet=wallet)
+        assert server is not None
+
+
+class TestMintVirtualCardTool:
+    """Test mint_virtual_card MCP tool."""
+
+    def test_successful_mint(self):
+        server, wallet = _make_server(
+            policy=SpendPolicy(max_transaction=50.0, daily_budget=200.0)
+        )
+        result = wallet.request_spend(4.20, "Anthropic", "need credits")
+        assert "Card approved" in result
+
+    def test_policy_denied_exceeds_cap(self):
+        server, wallet = _make_server(policy=SpendPolicy(max_transaction=10.0))
+        with pytest.raises(Exception, match="exceeds limit"):
+            wallet.request_spend(50.0, "vendor", "reason")
+
+    def test_policy_denied_blocked_vendor(self):
+        server, wallet = _make_server(policy=SpendPolicy(blocked_vendors=["doordash"]))
+        with pytest.raises(Exception, match="blocked"):
+            wallet.request_spend(5.0, "DoorDash", "lunch")
+
+
+class TestBudgetStatus:
+    """Test budget status reporting via wallet internals."""
+
+    def test_initial_budget_is_full(self):
+        _, wallet = _make_server(policy=SpendPolicy(daily_budget=200.0))
+        engine = wallet.policy_engine
+        assert engine._daily_spend == 0.0
+        assert engine.policy.daily_budget == 200.0
+
+    def test_budget_decreases_after_spend(self):
+        _, wallet = _make_server(
+            policy=SpendPolicy(max_transaction=100.0, daily_budget=200.0)
+        )
+        wallet.request_spend(30.0, "vendor", "reason")
+        engine = wallet.policy_engine
+        assert engine._daily_spend == 30.0
+
+    def test_time_based_budget_fields(self):
+        _, wallet = _make_server(
+            policy=SpendPolicy(
+                hourly_budget=50.0,
+                weekly_budget=300.0,
+                monthly_budget=1000.0,
+            )
+        )
+        policy = wallet.policy_engine.policy
+        assert policy.hourly_budget == 50.0
+        assert policy.weekly_budget == 300.0
+        assert policy.monthly_budget == 1000.0
+
+
+class TestPolicyInfo:
+    """Test policy info reporting."""
+
+    def test_default_policy_values(self):
+        _, wallet = _make_server()
+        policy = wallet.policy_engine.policy
+        assert policy.max_transaction == 50.0
+        assert policy.daily_budget == 200.0
+        assert policy.require_justification is True
+
+    def test_custom_policy_values(self):
+        _, wallet = _make_server(
+            policy=SpendPolicy(
+                max_transaction=100.0,
+                daily_budget=500.0,
+                blocked_vendors=["doordash", "ubereats"],
+            )
+        )
+        policy = wallet.policy_engine.policy
+        assert policy.max_transaction == 100.0
+        assert policy.daily_budget == 500.0
+        assert policy.blocked_vendors == ["doordash", "ubereats"]
+
+    def test_allowed_vendors_policy(self):
+        _, wallet = _make_server(
+            policy=SpendPolicy(allowed_vendors=["anthropic", "openai"])
+        )
+        policy = wallet.policy_engine.policy
+        assert policy.allowed_vendors == ["anthropic", "openai"]


### PR DESCRIPTION
## Add MCP Server Support

Implements the roadmap item to expose PayGraph spend governance tools as an MCP (Model Context Protocol) server, enabling any MCP-compatible AI client (Claude Desktop, Cursor, etc.) to request virtual cards and check budget status.

### Changes

- **`src/paygraph/mcp_server.py`** — New module with `create_mcp_server()` factory exposing three MCP tools:
  - `mint_virtual_card` — Request a policy-checked virtual card
  - `check_budget_status` — Check remaining budget across all time periods
  - `get_policy_info` — Get current spend policy configuration
- **`src/paygraph/cli.py`** — Added `paygraph mcp serve` subcommand with `--transport` (stdio/http) and `--port` options
- **`src/paygraph/__init__.py`** — Conditional export of `create_mcp_server` when MCP extras are installed
- **`pyproject.toml`** — Added `mcp = ["mcp>=1.0"]` optional dependency
- **`tests/test_mcp_server.py`** — 12 tests covering server creation, card minting, budget status, and policy info
- **`docs/mcp.md`** — Documentation for installation, usage, available tools, and Claude Desktop/Cursor configuration

### Usage

```bash
# Install with MCP extras
pip install paygraph[mcp]

# Run with stdio transport (for Claude Desktop, Cursor)
paygraph mcp serve

# Run with HTTP transport
paygraph mcp serve --transport http --port 8080