### PR TITLE
fix(wallet): raise UnknownApprovalError for unknown request_id in complete_spend

### DIFF
--- a/src/paygraph/__init__.py
+++ b/src/paygraph/__init__.py
@@ -4,6 +4,7 @@ from paygraph.exceptions import (
     PayGraphError,
     PolicyViolationError,
     SpendDeniedError,
+    UnknownApprovalError,
 )
 from paygraph.gateways.base import (
     BaseGateway,
@@ -41,4 +42,5 @@ __all__ = [
     "PolicyViolationError",
     "GatewayError",
     "HumanApprovalRequired",
+    "UnknownApprovalError",
 ]

--- a/src/paygraph/exceptions.py
+++ b/src/paygraph/exceptions.py
@@ -14,6 +14,17 @@ class GatewayError(PayGraphError):
     """Gateway API call failed."""
 
 
+class UnknownApprovalError(PayGraphError):
+    """No pending approval matches the given ``request_id``.
+
+    Raised by :meth:`AgentWallet.complete_spend` when the ``request_id`` is
+    not in the gateway's pending store. Common causes: the entry was already
+    completed by a previous call, the process restarted between
+    ``request_spend`` and ``complete_spend`` (in-memory pending store lost),
+    or the id was never issued.
+    """
+
+
 class HumanApprovalRequired(PayGraphError):
     """Spend requires human approval via Slack before proceeding.
 

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -6,6 +6,7 @@ from paygraph.exceptions import (
     HumanApprovalRequired,
     PolicyViolationError,
     SpendDeniedError,
+    UnknownApprovalError,
 )
 from paygraph.gateways.base import BaseGateway, CardResult, SpendResult
 from paygraph.gateways.mock import MockGateway
@@ -359,13 +360,22 @@ class AgentWallet:
         Raises:
             GatewayError: If the gateway is not a ``SlackApprovalGateway``.
             SpendDeniedError: If ``approved`` is ``False``.
+            UnknownApprovalError: If ``request_id`` is not in the gateway's
+                pending store (already completed, expired, or from a
+                previous process).
         """
         gw = self._resolve_gateway(gateway)
         if not isinstance(gw, SlackApprovalGateway):
             raise GatewayError("complete_spend requires a SlackApprovalGateway.")
 
         # Peek at pending metadata before complete_spend() pops it
-        pending = gw.get_pending(request_id)
+        try:
+            pending = gw.get_pending(request_id)
+        except KeyError as e:
+            raise UnknownApprovalError(
+                f"No pending approval found for request_id '{request_id}' "
+                f"(already completed, expired, or from a previous process)."
+            ) from e
         amount = pending["amount_cents"] / 100
         vendor = pending["vendor"]
         justification = pending["justification"]

--- a/tests/test_slack_gateway.py
+++ b/tests/test_slack_gateway.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from paygraph.exceptions import GatewayError, HumanApprovalRequired, SpendDeniedError
+from paygraph.exceptions import (
+    GatewayError,
+    HumanApprovalRequired,
+    SpendDeniedError,
+    UnknownApprovalError,
+)
 from paygraph.gateways.base import VirtualCard
 from paygraph.gateways.mock import MockGateway
 from paygraph.gateways.slack import SlackApprovalGateway
@@ -284,3 +289,51 @@ class TestWalletSlackFlow:
         assert approved_record["vendor"] == "Anthropic"
         assert approved_record["justification"] == "need tokens for task"
         assert approved_record["amount"] == 50.0
+
+
+class TestCompleteSpendUnknownRequestId:
+    """complete_spend must raise UnknownApprovalError, not bare KeyError,
+    when the request_id is unknown — covers stale ids after a process restart
+    and double-completion of the same id."""
+
+    def test_unknown_request_id_raises_unknown_approval_error(self):
+        """A request_id never issued by this wallet raises UnknownApprovalError."""
+        wallet, _ = _make_slack_wallet()
+        with pytest.raises(UnknownApprovalError, match="No pending approval"):
+            wallet.complete_spend("nonexistent_id", approved=True)
+
+    def test_stale_request_id_after_process_restart_raises_unknown_approval_error(self):
+        """Simulate a restart: the request was issued by an earlier wallet whose
+        in-memory _pending dict is gone. A fresh wallet sees the id as unknown."""
+        # First wallet issues an approval, then the request_id leaks out.
+        wallet_before, _ = _make_slack_wallet()
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet_before.request_spend(50.0, "Anthropic", "need tokens")
+        stale_id = exc_info.value.request_id
+
+        # Second wallet has no record of stale_id (fresh _pending dict).
+        wallet_after, _ = _make_slack_wallet()
+        with pytest.raises(UnknownApprovalError, match=stale_id):
+            wallet_after.complete_spend(stale_id, approved=True)
+
+    def test_double_completion_raises_unknown_approval_error(self):
+        """The second complete_spend on the same id must raise UnknownApprovalError."""
+        wallet, _ = _make_slack_wallet()
+        with patch("httpx.post"):
+            with pytest.raises(HumanApprovalRequired) as exc_info:
+                wallet.request_spend(50.0, "Anthropic", "need tokens")
+
+        request_id = exc_info.value.request_id
+        wallet.complete_spend(request_id, approved=True)
+        with pytest.raises(UnknownApprovalError, match=request_id):
+            wallet.complete_spend(request_id, approved=True)
+
+    def test_unknown_approval_error_is_paygraph_error(self):
+        """UnknownApprovalError subclasses PayGraphError so existing
+        ``except PayGraphError`` blocks continue to catch it."""
+        from paygraph.exceptions import PayGraphError
+
+        wallet, _ = _make_slack_wallet()
+        with pytest.raises(PayGraphError):
+            wallet.complete_spend("nonexistent_id", approved=True)


### PR DESCRIPTION
## Summary

`AgentWallet.complete_spend(request_id, …)` previously leaked a bare `KeyError` when `request_id` wasn't in the gateway's pending store, common when the `request_id` is stale, already completed, or unknown to the gateway. `KeyError` wasn't in the declared `Raises:` block, so callers had no typed way to handle it.

This PR adds `UnknownApprovalError(PayGraphError)` and raises it from `complete_spend` when the `get_pending` lookup fails.

## Why

- The bare `KeyError` was an undocumented escape from the `complete_spend` API surface.
- Callers building Slack approval flows (or any HITL pause/resume pattern) need to distinguish "id is unknown" from "human denied" / "policy rejected" / "gateway down".
- Complements PR #28 (TTL): #28 uses `SpendDeniedError("…timed out")` for the distinct *expired* case. This PR handles the case where the gateway has no record of the id at all.

## Changes

- `src/paygraph/exceptions.py` — new `UnknownApprovalError(PayGraphError)`
- `src/paygraph/__init__.py` — re-export, matching sibling exception exports
- `src/paygraph/wallet.py` — wrap `gw.get_pending(request_id)` in `try/except KeyError`, re-raise as `UnknownApprovalError` with `from e` to preserve the underlying cause; add to the `Raises:` block in the docstring
- `tests/test_slack_gateway.py` — new `TestCompleteSpendUnknownRequestId` class with 4 tests:
  - unknown id (never issued)
  - stale id from a *separate* gateway instance (simulates process restart with a real, gateway-issued `request_id`)
  - double completion of the same id
  - subclass-of-`PayGraphError` invariant so existing `except PayGraphError` blocks keep catching

## Backwards compatibility

`UnknownApprovalError` subclasses `PayGraphError` (same level as `SpendDeniedError` / `PolicyViolationError` / `GatewayError` / `HumanApprovalRequired`). Existing `except PayGraphError` blocks continue to catch it. No behaviour change on the happy path.

## Test plan

- [x] `make check` passes locally on Python 3.11 (137 tests, was 133 — +4 new)
- [x] Ruff clean
- [x] New test class verified independently: `pytest tests/test_slack_gateway.py::TestCompleteSpendUnknownRequestId -v`
- [x] No existing test required modification
