### PR TITLE
fix(cli): widen STRIPE_BILLING_* env vars so non-US Stripe Issuing works

### DIFF
--- a/src/paygraph/cli.py
+++ b/src/paygraph/cli.py
@@ -7,6 +7,65 @@ from paygraph.gateways.mock import MockGateway
 from paygraph.policy import SpendPolicy
 from paygraph.wallet import AgentWallet
 
+_BILLING_ENV_VARS = {
+    "line1": "STRIPE_BILLING_LINE1",
+    "line2": "STRIPE_BILLING_LINE2",
+    "city": "STRIPE_BILLING_CITY",
+    "state": "STRIPE_BILLING_STATE",
+    "postal_code": "STRIPE_BILLING_POSTAL_CODE",
+    "country": "STRIPE_BILLING_COUNTRY",
+}
+_REQUIRED_BILLING_FIELDS = ("line1", "city", "postal_code", "country")
+
+
+def _resolve_stripe_billing_address(
+    env: dict[str, str] | None = None,
+) -> dict[str, str] | None:
+    """Build a Stripe billing address dict from environment variables.
+
+    Returns ``None`` when no ``STRIPE_BILLING_*`` variable is set, letting
+    ``StripeCardGateway`` fall back to its US default. When any of the six
+    ``STRIPE_BILLING_*`` variables is set, the four required fields
+    (``line1``, ``city``, ``postal_code``, ``country``) must all be set;
+    ``line2`` and ``state`` are optional.
+
+    Args:
+        env: Environment mapping to read from. Defaults to ``os.environ``.
+            Exposed for tests so they can drive the helper without mutating
+            the real environment.
+
+    Returns:
+        A dict suitable for ``StripeCardGateway(billing_address=...)``, or
+        ``None`` if no billing variables are set.
+
+    Raises:
+        SystemExit: If the configuration is partial (one or more of the
+            required fields is missing) — surfaces a message listing the
+            missing variables before exiting.
+    """
+    env = env if env is not None else os.environ
+    values = {field: env.get(var) for field, var in _BILLING_ENV_VARS.items()}
+
+    if not any(values.values()):
+        return None
+
+    missing = [
+        _BILLING_ENV_VARS[field]
+        for field in _REQUIRED_BILLING_FIELDS
+        if not values[field]
+    ]
+    if missing:
+        print(
+            "ERROR: Stripe billing address is partially configured.\n"
+            "Set all four required variables together: "
+            f"{', '.join(_BILLING_ENV_VARS[f] for f in _REQUIRED_BILLING_FIELDS)}.\n"
+            f"Missing: {', '.join(missing)}.\n"
+            "STRIPE_BILLING_LINE2 and STRIPE_BILLING_STATE are optional."
+        )
+        raise SystemExit(1)
+
+    return {field: value for field, value in values.items() if value}
+
 
 def run_demo() -> None:
     print()
@@ -146,17 +205,7 @@ def run_live_demo(model: str, stripe: bool = False, stripe_mpp: bool = False) ->
             )
             raise SystemExit(1)
         currency = os.environ.get("STRIPE_CURRENCY", "usd")
-        billing_country = os.environ.get("STRIPE_BILLING_COUNTRY")
-        billing_address = (
-            {
-                "line1": "N/A",
-                "city": "N/A",
-                "postal_code": "00000",
-                "country": billing_country,
-            }
-            if billing_country
-            else None
-        )
+        billing_address = _resolve_stripe_billing_address()
         cardholder_id = os.environ.get("STRIPE_CARDHOLDER_ID")
         gateway = StripeCardGateway(
             api_key=stripe_key,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,105 @@
+import pytest
+
+from paygraph.cli import _resolve_stripe_billing_address
+
+
+class TestResolveStripeBillingAddress:
+    def test_no_env_vars_returns_none(self):
+        """No STRIPE_BILLING_* variables set → None (gateway uses US default)."""
+        assert _resolve_stripe_billing_address(env={}) is None
+
+    def test_unrelated_env_vars_returns_none(self):
+        """Variables outside the STRIPE_BILLING_* set are ignored."""
+        env = {"STRIPE_API_KEY": "sk_test_x", "PATH": "/usr/bin"}
+        assert _resolve_stripe_billing_address(env=env) is None
+
+    def test_full_us_address(self):
+        """All required fields set + state → full US dict."""
+        env = {
+            "STRIPE_BILLING_LINE1": "1 Market St",
+            "STRIPE_BILLING_CITY": "San Francisco",
+            "STRIPE_BILLING_STATE": "CA",
+            "STRIPE_BILLING_POSTAL_CODE": "94105",
+            "STRIPE_BILLING_COUNTRY": "US",
+        }
+        assert _resolve_stripe_billing_address(env=env) == {
+            "line1": "1 Market St",
+            "city": "San Francisco",
+            "state": "CA",
+            "postal_code": "94105",
+            "country": "US",
+        }
+
+    def test_full_french_address_no_state(self):
+        """French address — no state, all four required fields present."""
+        env = {
+            "STRIPE_BILLING_LINE1": "10 rue de Rivoli",
+            "STRIPE_BILLING_CITY": "Paris",
+            "STRIPE_BILLING_POSTAL_CODE": "75001",
+            "STRIPE_BILLING_COUNTRY": "FR",
+        }
+        result = _resolve_stripe_billing_address(env=env)
+        assert result == {
+            "line1": "10 rue de Rivoli",
+            "city": "Paris",
+            "postal_code": "75001",
+            "country": "FR",
+        }
+        assert "state" not in result
+
+    def test_line2_is_optional(self):
+        """LINE2 is included when set, omitted when not."""
+        env = {
+            "STRIPE_BILLING_LINE1": "Hauptstrasse 1",
+            "STRIPE_BILLING_LINE2": "Apt 5B",
+            "STRIPE_BILLING_CITY": "Berlin",
+            "STRIPE_BILLING_POSTAL_CODE": "10115",
+            "STRIPE_BILLING_COUNTRY": "DE",
+        }
+        result = _resolve_stripe_billing_address(env=env)
+        assert result["line2"] == "Apt 5B"
+
+    def test_legacy_country_only_raises_systemexit(self):
+        """The old ``STRIPE_BILLING_COUNTRY=FR`` shorthand is rejected loudly.
+
+        The pre-fix CLI silently produced ``{line1: 'N/A', city: 'N/A',
+        postal_code: '00000', country: 'FR'}`` which Stripe rejects for
+        most non-US countries. Failing fast with a clear instruction is
+        better than silently calling a broken Stripe request.
+        """
+        env = {"STRIPE_BILLING_COUNTRY": "FR"}
+        with pytest.raises(SystemExit):
+            _resolve_stripe_billing_address(env=env)
+
+    def test_partial_address_lists_missing_vars(self, capsys):
+        """Error output names every missing required variable."""
+        env = {
+            "STRIPE_BILLING_LINE1": "10 rue de Rivoli",
+            "STRIPE_BILLING_COUNTRY": "FR",
+        }
+        with pytest.raises(SystemExit):
+            _resolve_stripe_billing_address(env=env)
+        captured = capsys.readouterr()
+        assert "STRIPE_BILLING_CITY" in captured.out
+        assert "STRIPE_BILLING_POSTAL_CODE" in captured.out
+        # Already-set fields must not appear in the missing list
+        missing_section = captured.out.split("Missing:", 1)[1]
+        assert "STRIPE_BILLING_LINE1" not in missing_section
+        assert "STRIPE_BILLING_COUNTRY" not in missing_section
+
+    def test_optional_only_is_partial(self):
+        """Setting only LINE2 or STATE without the required fields is partial."""
+        env = {"STRIPE_BILLING_STATE": "CA"}
+        with pytest.raises(SystemExit):
+            _resolve_stripe_billing_address(env=env)
+
+    def test_empty_string_treated_as_unset(self):
+        """An empty string env var counts as unset (matches ``os.environ.get``)."""
+        env = {
+            "STRIPE_BILLING_LINE1": "1 Market St",
+            "STRIPE_BILLING_CITY": "",
+            "STRIPE_BILLING_POSTAL_CODE": "94105",
+            "STRIPE_BILLING_COUNTRY": "US",
+        }
+        with pytest.raises(SystemExit):
+            _resolve_stripe_billing_address(env=env)


### PR DESCRIPTION
## Summary

`STRIPE_BILLING_COUNTRY=FR` (or any non-US country) on its own produced `{line1: "N/A", city: "N/A", postal_code: "00000", country: "FR"}`, which Stripe Issuing rejects in most non-US countries. The live demo fell over with an opaque Stripe 400 instead of a useful CLI message.

This PR replaces the shortcut with the full address surface and fails fast when the config is partial.

## Changes

- `src/paygraph/cli.py`: new `_resolve_stripe_billing_address(env=None)` helper. Six env vars: `STRIPE_BILLING_LINE1`, `STRIPE_BILLING_LINE2`, `STRIPE_BILLING_CITY`, `STRIPE_BILLING_STATE`, `STRIPE_BILLING_POSTAL_CODE`, `STRIPE_BILLING_COUNTRY`. Four required (`LINE1`, `CITY`, `POSTAL_CODE`, `COUNTRY`); `LINE2` and `STATE` optional. Empty strings count as unset. No vars set returns `None`, so `StripeCardGateway` keeps its US default. Partial config raises `SystemExit(1)` listing the missing vars, matching the existing CLI error pattern.
- `tests/test_cli.py`: new file, 9 tests covering full US, full FR (no state), optional `LINE2`, legacy `COUNTRY`-only, partial config error wording, optional-only is partial, empty string is unset, and unrelated env vars ignored.

## Backwards compatibility

Anyone relying on the legacy `STRIPE_BILLING_COUNTRY=FR` shorthand was already getting a broken Stripe request. They now get a clear CLI error naming the right env vars instead of a Stripe 400 mid-demo. US users who set nothing keep working unchanged.

## Test plan

- [x] `make check` passes locally on Python 3.11 (142 tests, +9 new)
- [x] Ruff clean
- [x] `pytest tests/test_cli.py -v`: 9/9 pass