### PR TITLE
feat(listeners): Slack webhook listener for auto-resolving approvals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ live = ["langgraph>=0.2", "langchain-anthropic>=0.2", "langchain-openai>=0.2"]
 slack = ["fastapi>=0.110", "python-multipart>=0.0.9"]
 x402 = ["x402[httpx,evm,svm]"]
 docs = ["mkdocs-material", "mkdocstrings[python]"]
-dev = ["ruff>=0.4", "pytest>=8.0", "fastapi>=0.110", "python-multipart>=0.0.9"]
+dev = ["ruff>=0.4", "pytest>=8.0"]
 
 [project.scripts]
 paygraph = "paygraph.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,10 @@ dependencies = ["pydantic", "httpx"]
 langgraph = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.80", "langchain-core>=0.2"]
 live = ["langgraph>=0.2", "langchain-anthropic>=0.2", "langchain-openai>=0.2"]
+slack = ["fastapi>=0.110", "python-multipart>=0.0.9"]
 x402 = ["x402[httpx,evm,svm]"]
 docs = ["mkdocs-material", "mkdocstrings[python]"]
-dev = ["ruff>=0.4", "pytest>=8.0"]
+dev = ["ruff>=0.4", "pytest>=8.0", "fastapi>=0.110", "python-multipart>=0.0.9"]
 
 [project.scripts]
 paygraph = "paygraph.cli:main"

--- a/src/paygraph/__init__.py
+++ b/src/paygraph/__init__.py
@@ -23,7 +23,6 @@ from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.gateways.stripe import StripeCardGateway
 from paygraph.gateways.stripe_mpp import StripeMPPGateway
 from paygraph.gateways.x402 import X402Gateway, X402Receipt
-from paygraph.listeners import SlackListener
 from paygraph.policy import SpendPolicy
 from paygraph.wallet import AgentWallet
 
@@ -40,7 +39,6 @@ __all__ = [
     "StripeMPPGateway",
     "MockGateway",
     "SlackApprovalGateway",
-    "SlackListener",
     "X402Gateway",
     "MockX402Gateway",
     "PayGraphError",

--- a/src/paygraph/__init__.py
+++ b/src/paygraph/__init__.py
@@ -23,6 +23,7 @@ from paygraph.gateways.slack import SlackApprovalGateway
 from paygraph.gateways.stripe import StripeCardGateway
 from paygraph.gateways.stripe_mpp import StripeMPPGateway
 from paygraph.gateways.x402 import X402Gateway, X402Receipt
+from paygraph.listeners import SlackListener
 from paygraph.policy import SpendPolicy
 from paygraph.wallet import AgentWallet
 
@@ -39,6 +40,7 @@ __all__ = [
     "StripeMPPGateway",
     "MockGateway",
     "SlackApprovalGateway",
+    "SlackListener",
     "X402Gateway",
     "MockX402Gateway",
     "PayGraphError",

--- a/src/paygraph/listeners/__init__.py
+++ b/src/paygraph/listeners/__init__.py
@@ -1,0 +1,3 @@
+from paygraph.listeners.slack import SlackListener
+
+__all__ = ["SlackListener"]

--- a/src/paygraph/listeners/slack.py
+++ b/src/paygraph/listeners/slack.py
@@ -1,0 +1,244 @@
+"""HTTP listener that resolves Slack approval responses automatically.
+
+Without this listener, callers must build their own HTTP server to receive
+Slack interaction payloads and call ``wallet.complete_spend()``. The listener
+exposes a Slack-compatible endpoint (``POST /paygraph/slack/callback``),
+verifies the Slack request signature, and routes the response to the wallet
+that owns the pending ``request_id``.
+
+**Slack app setup required.** ``SlackApprovalGateway`` posts approval requests
+via an incoming webhook (plain text). Incoming webhooks cannot receive
+interaction callbacks, so to use this listener you must configure a separate
+Slack app with *Interactivity* enabled and its Request URL pointed at the
+endpoint this listener exposes. The Slack app's Block Kit message should
+include Approve/Deny buttons whose ``action_id`` is ``"approve"`` or
+``"deny"`` and whose ``value`` is the ``request_id`` from
+``HumanApprovalRequired``.
+
+Example::
+
+    from fastapi import FastAPI
+    from paygraph import AgentWallet, SpendPolicy, SlackApprovalGateway
+    from paygraph.gateways.mock import MockGateway
+    from paygraph.listeners import SlackListener
+
+    wallet = AgentWallet(
+        gateways=SlackApprovalGateway(
+            webhook_url="https://hooks.slack.com/...",
+            inner_gateway=MockGateway(auto_approve=True),
+        ),
+        policy=SpendPolicy(require_human_approval_above=20.0),
+    )
+
+    listener = SlackListener(signing_secret="...")
+    listener.register(wallet)
+
+    # Standalone:
+    #   uvicorn myapp:app --host 0.0.0.0 --port 8080
+    app = listener.app()
+
+    # Or embed in an existing FastAPI app:
+    #   parent = FastAPI()
+    #   listener.mount(parent, path="/paygraph/slack/callback")
+"""
+
+import hashlib
+import hmac
+import json
+import time
+from typing import TYPE_CHECKING, Optional
+
+from paygraph.exceptions import SpendDeniedError, UnknownApprovalError
+from paygraph.gateways.slack import SlackApprovalGateway
+
+if TYPE_CHECKING:  # pragma: no cover
+    from fastapi import FastAPI
+
+    from paygraph.wallet import AgentWallet
+
+
+DEFAULT_CALLBACK_PATH = "/paygraph/slack/callback"
+SIGNATURE_TOLERANCE_SECONDS = 60 * 5  # Slack's recommended replay window
+
+
+class SlackListener:
+    """FastAPI listener that resolves Slack interaction payloads.
+
+    Verifies Slack's signed requests (HMAC-SHA256 over ``v0:<timestamp>:<body>``)
+    and dispatches the human's Approve/Deny click to the right wallet.
+
+    Routing: the listener iterates through registered wallets and asks each
+    ``SlackApprovalGateway`` whether it owns the incoming ``request_id``. The
+    first gateway that recognises the id receives ``complete_spend()``.
+    """
+
+    def __init__(self, signing_secret: str) -> None:
+        """Initialise the listener.
+
+        Args:
+            signing_secret: The Slack app's signing secret. Used to verify
+                that incoming requests originated from Slack and not a forger.
+                Find this in the Slack app's *Basic Information* page.
+        """
+        if not signing_secret:
+            raise ValueError("signing_secret is required for signature verification.")
+        self.signing_secret = signing_secret
+        self._wallets: list = []
+
+    def register(self, wallet: "AgentWallet") -> None:
+        """Register a wallet whose pending approvals this listener resolves.
+
+        Call once per wallet at startup. The listener will route any incoming
+        approval whose ``request_id`` is in one of this wallet's
+        ``SlackApprovalGateway._pending`` stores.
+        """
+        if wallet not in self._wallets:
+            self._wallets.append(wallet)
+
+    def verify_signature(
+        self, timestamp: str, body: bytes, slack_signature: str
+    ) -> bool:
+        """Verify Slack's request signature and timestamp.
+
+        Implements the spec at https://api.slack.com/authentication/verifying-requests-from-slack:
+        sigbase = ``f"v0:{timestamp}:{body}"`` → HMAC-SHA256 with signing secret →
+        ``f"v0={hexdigest}"`` compared with ``X-Slack-Signature``.
+
+        Args:
+            timestamp: The ``X-Slack-Request-Timestamp`` header value.
+            body: Raw request body bytes (must be the unparsed bytes Slack sent).
+            slack_signature: The ``X-Slack-Signature`` header value.
+
+        Returns:
+            True iff the timestamp is within the replay window AND the
+            signature matches.
+        """
+        if not timestamp or not slack_signature:
+            return False
+        try:
+            ts = int(timestamp)
+        except ValueError:
+            return False
+        if abs(time.time() - ts) > SIGNATURE_TOLERANCE_SECONDS:
+            return False
+
+        sigbase = b"v0:" + timestamp.encode("utf-8") + b":" + body
+        digest = hmac.new(
+            self.signing_secret.encode("utf-8"), sigbase, hashlib.sha256
+        ).hexdigest()
+        expected = "v0=" + digest
+        return hmac.compare_digest(expected, slack_signature)
+
+    def _find_owner(self, request_id: str) -> Optional[tuple]:
+        """Return ``(wallet, gateway_name)`` for the gateway that owns ``request_id``."""
+        for wallet in self._wallets:
+            for name, gw in wallet._gateways.items():
+                if not isinstance(gw, SlackApprovalGateway):
+                    continue
+                try:
+                    gw.get_pending(request_id)
+                except KeyError:
+                    continue
+                return wallet, name
+        return None
+
+    def handle_payload(self, payload: dict) -> dict:
+        """Resolve a parsed Slack ``block_actions`` interaction payload.
+
+        Expects a Block Kit payload (the modern format — see
+        https://docs.slack.dev/reference/interaction-payloads/block_actions-payload)::
+
+            {
+                "type": "block_actions",
+                "actions": [
+                    {
+                        "action_id": "approve",   # or "deny"
+                        "value": "<request_id>",
+                        "type": "button",
+                        ...
+                    }
+                ],
+                ...
+            }
+
+        Returns a JSON-serialisable dict suitable for the HTTP response body.
+        Slack only requires a ``200 OK`` for acknowledgement; the body is
+        useful for tests and for callers who want to surface the result.
+        """
+        actions = payload.get("actions") or []
+        if not actions:
+            return {"ok": False, "error": "missing_actions"}
+
+        action = actions[0]
+        decision = (action.get("action_id") or "").lower()
+        request_id = action.get("value")
+        if decision not in {"approve", "deny"}:
+            return {"ok": False, "error": f"unknown action_id: {decision!r}"}
+        if not request_id:
+            return {"ok": False, "error": "missing_request_id"}
+
+        owner = self._find_owner(request_id)
+        if owner is None:
+            return {
+                "ok": False,
+                "error": "unknown_request_id",
+                "request_id": request_id,
+            }
+
+        wallet, gateway_name = owner
+        approved = decision == "approve"
+        try:
+            wallet.complete_spend(request_id, approved=approved, gateway=gateway_name)
+        except SpendDeniedError as e:
+            return {"ok": True, "approved": False, "reason": str(e)}
+        except UnknownApprovalError as e:
+            return {"ok": False, "error": "unknown_request_id", "reason": str(e)}
+        return {"ok": True, "approved": True}
+
+    def app(self, path: str = DEFAULT_CALLBACK_PATH) -> "FastAPI":
+        """Return a standalone FastAPI app exposing the callback endpoint."""
+        try:
+            from fastapi import FastAPI
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "SlackListener requires the 'slack' extra. "
+                "Install with: pip install paygraph[slack]"
+            ) from e
+
+        app = FastAPI(title="paygraph-slack-listener")
+        self.mount(app, path=path)
+        return app
+
+    def mount(self, app: "FastAPI", path: str = DEFAULT_CALLBACK_PATH) -> None:
+        """Mount the callback route onto an existing FastAPI app."""
+        try:
+            from fastapi import Request
+            from fastapi.responses import JSONResponse
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "SlackListener requires the 'slack' extra. "
+                "Install with: pip install paygraph[slack]"
+            ) from e
+
+        @app.post(path)
+        async def slack_callback(request: Request) -> JSONResponse:
+            body = await request.body()
+            timestamp = request.headers.get("x-slack-request-timestamp", "")
+            signature = request.headers.get("x-slack-signature", "")
+            if not self.verify_signature(timestamp, body, signature):
+                return JSONResponse({"ok": False, "error": "invalid_signature"}, status_code=401)
+
+            # Slack posts interactive payloads as form-encoded with a single
+            # 'payload' field containing JSON.
+            form = await request.form()
+            raw_payload = form.get("payload")
+            if raw_payload is None:
+                return JSONResponse({"ok": False, "error": "missing_payload"}, status_code=400)
+            try:
+                payload = json.loads(raw_payload)
+            except json.JSONDecodeError:
+                return JSONResponse({"ok": False, "error": "invalid_json"}, status_code=400)
+
+            # Slack expects a 200 within 3s and retries on non-2xx. Always
+            # ack with 200; the body conveys the outcome for tests/observers.
+            return JSONResponse(self.handle_payload(payload), status_code=200)

--- a/src/paygraph/listeners/slack.py
+++ b/src/paygraph/listeners/slack.py
@@ -49,7 +49,6 @@ import time
 from typing import TYPE_CHECKING, Optional
 
 from paygraph.exceptions import SpendDeniedError, UnknownApprovalError
-from paygraph.gateways.slack import SlackApprovalGateway
 
 if TYPE_CHECKING:  # pragma: no cover
     from fastapi import FastAPI
@@ -132,14 +131,10 @@ class SlackListener:
     def _find_owner(self, request_id: str) -> Optional[tuple]:
         """Return ``(wallet, gateway_name)`` for the gateway that owns ``request_id``."""
         for wallet in self._wallets:
-            for name, gw in wallet._gateways.items():
-                if not isinstance(gw, SlackApprovalGateway):
-                    continue
-                try:
-                    gw.get_pending(request_id)
-                except KeyError:
-                    continue
-                return wallet, name
+            found = wallet.find_pending_approval(request_id)
+            if found is not None:
+                gateway_name, _ = found
+                return wallet, gateway_name
         return None
 
     def handle_payload(self, payload: dict) -> dict:

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -85,6 +85,27 @@ class AgentWallet:
             )
         return gw
 
+    def find_pending_approval(
+        self, request_id: str
+    ) -> tuple[str, SlackApprovalGateway] | None:
+        """Find the SlackApprovalGateway that owns ``request_id``.
+
+        Returns ``(gateway_name, gateway)`` for the first registered
+        ``SlackApprovalGateway`` whose pending store contains ``request_id``,
+        or ``None`` if no gateway owns it. Used by ``SlackListener`` to route
+        incoming Slack interaction payloads without reaching into wallet
+        internals.
+        """
+        for name, gw in self._gateways.items():
+            if not isinstance(gw, SlackApprovalGateway):
+                continue
+            try:
+                gw.get_pending(request_id)
+            except KeyError:
+                continue
+            return name, gw
+        return None
+
     def _execute_with_policy(
         self,
         gateway_name: str,

--- a/tests/test_slack_listener.py
+++ b/tests/test_slack_listener.py
@@ -1,0 +1,300 @@
+import hashlib
+import hmac
+import json
+import tempfile
+import time
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from paygraph import (
+    AgentWallet,
+    HumanApprovalRequired,
+    SlackApprovalGateway,
+    SlackListener,
+    SpendPolicy,
+)
+from paygraph.gateways.mock import MockGateway
+
+SIGNING_SECRET = "test-signing-secret"
+
+
+def _sign(body: bytes, timestamp: str, secret: str = SIGNING_SECRET) -> str:
+    """Produce a Slack-style signature for the given body+timestamp."""
+    sigbase = b"v0:" + timestamp.encode() + b":" + body
+    digest = hmac.new(secret.encode(), sigbase, hashlib.sha256).hexdigest()
+    return "v0=" + digest
+
+
+def _make_wallet(threshold: float = 20.0) -> tuple[AgentWallet, SlackApprovalGateway, str]:
+    f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+    f.close()
+    gateway = SlackApprovalGateway(
+        webhook_url="https://hooks.slack.com/test",
+        inner_gateway=MockGateway(auto_approve=True),
+    )
+    wallet = AgentWallet(
+        gateways=gateway,
+        policy=SpendPolicy(require_human_approval_above=threshold),
+        log_path=f.name,
+        verbose=False,
+    )
+    return wallet, gateway, f.name
+
+
+def _read_audit(path: str) -> list[dict]:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _issue_pending(wallet: AgentWallet, amount: float = 50.0) -> str:
+    with patch("httpx.post"):
+        with pytest.raises(HumanApprovalRequired) as exc_info:
+            wallet.request_spend(amount, "Anthropic", "need tokens")
+    return exc_info.value.request_id
+
+
+def _block_actions(request_id: str, decision: str = "approve") -> dict:
+    """Build a Block Kit ``block_actions`` payload like Slack would send."""
+    return {
+        "type": "block_actions",
+        "actions": [
+            {
+                "action_id": decision,
+                "value": request_id,
+                "type": "button",
+                "action_ts": "1548426417.840180",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureVerification:
+    def test_valid_signature_passes(self):
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        body = b"payload=%7B%7D"
+        ts = str(int(time.time()))
+        sig = _sign(body, ts)
+        assert listener.verify_signature(ts, body, sig) is True
+
+    def test_tampered_body_fails(self):
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        ts = str(int(time.time()))
+        sig = _sign(b"original", ts)
+        assert listener.verify_signature(ts, b"tampered", sig) is False
+
+    def test_wrong_secret_fails(self):
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        body = b"payload=x"
+        ts = str(int(time.time()))
+        sig = _sign(body, ts, secret="other-secret")
+        assert listener.verify_signature(ts, body, sig) is False
+
+    def test_expired_timestamp_fails(self):
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        body = b"payload=x"
+        ts = str(int(time.time()) - 10 * 60)  # 10 min old, outside 5 min window
+        sig = _sign(body, ts)
+        assert listener.verify_signature(ts, body, sig) is False
+
+    def test_future_timestamp_fails(self):
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        body = b"payload=x"
+        ts = str(int(time.time()) + 10 * 60)
+        sig = _sign(body, ts)
+        assert listener.verify_signature(ts, body, sig) is False
+
+    def test_missing_headers_fail(self):
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        assert listener.verify_signature("", b"x", "v0=abc") is False
+        assert listener.verify_signature("123", b"x", "") is False
+
+    def test_non_numeric_timestamp_fails(self):
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        assert listener.verify_signature("not-a-number", b"x", "v0=abc") is False
+
+    def test_empty_secret_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="signing_secret"):
+            SlackListener(signing_secret="")
+
+
+# ---------------------------------------------------------------------------
+# Payload handling (logic only, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePayload:
+    def test_approve_calls_complete_spend_and_audits_approval(self):
+        wallet, _, audit_path = _make_wallet()
+        request_id = _issue_pending(wallet)
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet)
+
+        result = listener.handle_payload(_block_actions(request_id, "approve"))
+        assert result == {"ok": True, "approved": True}
+        records = _read_audit(audit_path)
+        approved = [r for r in records if r["policy_result"] == "approved"]
+        assert len(approved) == 1
+        assert approved[0]["vendor"] == "Anthropic"
+        assert approved[0]["amount"] == 50.0
+
+    def test_deny_records_denial_in_audit(self):
+        wallet, _, audit_path = _make_wallet()
+        request_id = _issue_pending(wallet)
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet)
+
+        result = listener.handle_payload(_block_actions(request_id, "deny"))
+        assert result["ok"] is True
+        assert result["approved"] is False
+        assert "Human denied" in result["reason"]
+        denied = [r for r in _read_audit(audit_path) if r["policy_result"] == "denied"]
+        assert len(denied) == 1
+        assert "Human denied" in denied[0]["denial_reason"]
+
+    def test_unknown_request_id_returns_error(self):
+        wallet, _, _ = _make_wallet()
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet)
+
+        result = listener.handle_payload(_block_actions("ffffffffffffffff", "approve"))
+        assert result["ok"] is False
+        assert result["error"] == "unknown_request_id"
+
+    def test_missing_request_id_returns_error(self):
+        """A button with no ``value`` (request_id) cannot be routed."""
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        result = listener.handle_payload(
+            {
+                "type": "block_actions",
+                "actions": [{"action_id": "approve", "type": "button"}],
+            }
+        )
+        assert result["ok"] is False
+        assert result["error"] == "missing_request_id"
+
+    def test_missing_actions_returns_error(self):
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        result = listener.handle_payload({"type": "block_actions"})
+        assert result["ok"] is False
+        assert result["error"] == "missing_actions"
+
+    def test_unknown_action_id_returns_error(self):
+        wallet, _, _ = _make_wallet()
+        request_id = _issue_pending(wallet)
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet)
+
+        result = listener.handle_payload(_block_actions(request_id, "maybe"))
+        assert result["ok"] is False
+        assert "unknown action_id" in result["error"]
+
+    def test_routes_to_correct_wallet_when_multiple_registered(self):
+        wallet_a, _, audit_a = _make_wallet()
+        wallet_b, _, audit_b = _make_wallet()
+        request_id_b = _issue_pending(wallet_b)
+
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet_a)
+        listener.register(wallet_b)
+
+        result = listener.handle_payload(_block_actions(request_id_b, "approve"))
+        assert result == {"ok": True, "approved": True}
+        # Only wallet_b's audit should record the approval.
+        assert any(r["policy_result"] == "approved" for r in _read_audit(audit_b))
+        assert not any(r["policy_result"] == "approved" for r in _read_audit(audit_a))
+
+
+# ---------------------------------------------------------------------------
+# Full HTTP integration (FastAPI TestClient)
+# ---------------------------------------------------------------------------
+
+
+def _post_slack(client: TestClient, payload: dict, secret: str = SIGNING_SECRET) -> object:
+    """Form-encode a Slack interaction payload and sign it like Slack would."""
+    from urllib.parse import urlencode
+
+    body = urlencode({"payload": json.dumps(payload)}).encode()
+    ts = str(int(time.time()))
+    sig = _sign(body, ts, secret)
+    return client.post(
+        "/paygraph/slack/callback",
+        content=body,
+        headers={
+            "X-Slack-Request-Timestamp": ts,
+            "X-Slack-Signature": sig,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+
+
+class TestHttpEndpoint:
+    def test_full_loop_approve(self):
+        wallet, _, audit_path = _make_wallet()
+        request_id = _issue_pending(wallet)
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet)
+        client = TestClient(listener.app())
+
+        resp = _post_slack(client, _block_actions(request_id, "approve"))
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "approved": True}
+        approved = [
+            r for r in _read_audit(audit_path) if r["policy_result"] == "approved"
+        ]
+        assert len(approved) == 1
+
+    def test_invalid_signature_rejected(self):
+        wallet, _, _ = _make_wallet()
+        request_id = _issue_pending(wallet)
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet)
+        client = TestClient(listener.app())
+
+        resp = _post_slack(
+            client, _block_actions(request_id, "approve"), secret="forger-secret"
+        )
+        assert resp.status_code == 401
+        assert resp.json() == {"ok": False, "error": "invalid_signature"}
+
+    def test_can_mount_on_existing_app(self):
+        wallet, _, _ = _make_wallet()
+        request_id = _issue_pending(wallet)
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet)
+
+        parent = FastAPI()
+
+        @parent.get("/health")
+        def health():
+            return {"status": "ok"}
+
+        listener.mount(parent)
+        client = TestClient(parent)
+        assert client.get("/health").json() == {"status": "ok"}
+
+        resp = _post_slack(client, _block_actions(request_id, "approve"))
+        assert resp.status_code == 200
+
+    def test_unknown_request_id_returns_200_per_slack_contract(self):
+        """Slack retries on non-2xx, so unknown request_id still acks 200.
+        The body conveys the error."""
+        wallet, _, _ = _make_wallet()
+        listener = SlackListener(signing_secret=SIGNING_SECRET)
+        listener.register(wallet)
+        client = TestClient(listener.app())
+
+        resp = _post_slack(client, _block_actions("ffffffffffffffff", "approve"))
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is False
+        assert resp.json()["error"] == "unknown_request_id"

--- a/tests/test_slack_listener.py
+++ b/tests/test_slack_listener.py
@@ -16,10 +16,10 @@ from paygraph import (
     AgentWallet,
     HumanApprovalRequired,
     SlackApprovalGateway,
-    SlackListener,
     SpendPolicy,
 )
 from paygraph.gateways.mock import MockGateway
+from paygraph.listeners import SlackListener
 
 SIGNING_SECRET = "test-signing-secret"
 


### PR DESCRIPTION
Closes #22.

## What this does

Adds an in-process FastAPI listener for Slack approval callbacks, so users don’t need to run their own HTTP server.

* `paygraph.listeners.SlackListener`
* Exposes `POST /paygraph/slack/callback`
* Verifies Slack signatures (`v0:<ts>:<body>`, HMAC-SHA256, 5-minute replay window)
* Routes `block_actions` payloads:

  * `action_id` → approve/deny
  * `value` → `request_id`
* Supports multi-wallet routing via `listener.register(wallet)`
* Can be embedded with `listener.app()` or `listener.mount(parent_app)`
* Returns:

  * `200` for parsed payloads
  * `401` for invalid signatures
* Adds new `slack` extra dependencies:

  * `fastapi`
  * `python-multipart`

## Setup

`SlackApprovalGateway` still sends plain-text incoming webhooks (incoming webhooks cannot receive callbacks).

To use the listener:

* Create a separate Slack app
* Enable Interactivity
* Set the Request URL to `/paygraph/slack/callback`
* Use Block Kit buttons with:

  * `action_id="approve"` or `"deny"`
  * `value=<request_id>`

## Out of scope

* Durable storage (Redis/SQLite)
* Multi-channel support
* Native bot-token Block Kit gateway

## Test plan

* [x] `uv run pytest tests/` → 192 passing tests
* [x] Ruff clean
* [x] Added 19 new tests:

  * 8 signature verification
  * 7 payload routing
  * 4 FastAPI integration tests