### PR TITLE
feat: add policy replay simulator and CLI command for audit log replay

### DIFF
--- a/src/paygraph/__init__.py
+++ b/src/paygraph/__init__.py
@@ -24,6 +24,7 @@ from paygraph.gateways.stripe import StripeCardGateway
 from paygraph.gateways.stripe_mpp import StripeMPPGateway
 from paygraph.gateways.x402 import X402Gateway, X402Receipt
 from paygraph.policy import SpendPolicy
+from paygraph.simulator import PolicySimulator, ReplayOutcome, ReplayReport
 from paygraph.wallet import AgentWallet
 
 __all__ = [
@@ -51,4 +52,7 @@ __all__ = [
     "StripeUnreachableError",
     "HumanApprovalRequired",
     "UnknownApprovalError",
+    "PolicySimulator",
+    "ReplayOutcome",
+    "ReplayReport",
 ]

--- a/src/paygraph/audit.py
+++ b/src/paygraph/audit.py
@@ -52,6 +52,7 @@ class AuditRecord:
     checks_passed: list[str]
     gateway_ref: str | None
     gateway_type: str | None
+    policy_snapshot: dict | None = None
 
     @classmethod
     def now(
@@ -65,6 +66,7 @@ class AuditRecord:
         checks_passed: list[str] | None = None,
         gateway_ref: str | None = None,
         gateway_type: str | None = None,
+        policy_snapshot: dict | None = None,
     ) -> "AuditRecord":
         """Create an AuditRecord with the current UTC timestamp.
 
@@ -78,6 +80,10 @@ class AuditRecord:
             checks_passed: List of passed policy check names.
             gateway_ref: Gateway reference ID.
             gateway_type: Gateway type string.
+            policy_snapshot: Full ``SpendPolicy`` (as a dict) that was active
+                when this record was written. Enables deterministic replay of
+                historical records against a candidate policy. May be ``None``
+                for records written before this field was introduced.
 
         Returns:
             A new ``AuditRecord`` with ``timestamp`` set to now (UTC).
@@ -93,6 +99,7 @@ class AuditRecord:
             checks_passed=checks_passed or [],
             gateway_ref=gateway_ref,
             gateway_type=gateway_type,
+            policy_snapshot=policy_snapshot,
         )
 
 

--- a/src/paygraph/cli.py
+++ b/src/paygraph/cli.py
@@ -1,6 +1,9 @@
 import argparse
+import json
 import os
+import sys
 import tempfile
+from dataclasses import asdict
 
 from paygraph.exceptions import PolicyViolationError
 from paygraph.gateways.mock import MockGateway
@@ -361,6 +364,28 @@ def run_live_demo(model: str, stripe: bool = False, stripe_mpp: bool = False) ->
     os.unlink(audit_path)
 
 
+def run_replay(audit_log: str, policy_path: str, all_rows: bool, as_json: bool) -> int:
+    """Run the ``paygraph replay`` subcommand. Returns a process exit code."""
+    from paygraph.simulator import PolicySimulator, load_policy_json
+
+    if not os.path.exists(audit_log):
+        print(f"ERROR: audit log not found: {audit_log}", file=sys.stderr)
+        return 1
+    if not os.path.exists(policy_path):
+        print(f"ERROR: policy file not found: {policy_path}", file=sys.stderr)
+        return 1
+
+    candidate = load_policy_json(policy_path)
+    sim = PolicySimulator(candidate)
+    report = sim.replay_file(audit_log, only_approved=not all_rows)
+
+    if as_json:
+        print(json.dumps(asdict(report), indent=2))
+    else:
+        print(report.summary())
+    return 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="paygraph",
@@ -398,6 +423,26 @@ def main() -> None:
     mcp_sub = mcp_parser.add_subparsers(dest="mcp_command")
     mcp_sub.add_parser("serve", help="Run the PayGraph MCP server over stdio")
 
+    replay_parser = subparsers.add_parser(
+        "replay", help="Replay an audit log against a candidate SpendPolicy"
+    )
+    replay_parser.add_argument("audit_log", help="Path to audit JSONL file")
+    replay_parser.add_argument(
+        "--policy",
+        required=True,
+        help="Path to candidate SpendPolicy as JSON",
+    )
+    replay_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Re-evaluate denied rows too (default: only previously-approved rows)",
+    )
+    replay_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the ReplayReport as JSON instead of a human-readable table",
+    )
+
     args = parser.parse_args()
 
     if args.command == "demo":
@@ -408,6 +453,14 @@ def main() -> None:
             run_live_demo(args.model, stripe=args.stripe, stripe_mpp=args.stripe_mpp)
         else:
             run_demo()
+    elif args.command == "replay":
+        exit_code = run_replay(
+            audit_log=args.audit_log,
+            policy_path=args.policy,
+            all_rows=args.all,
+            as_json=args.json,
+        )
+        raise SystemExit(exit_code)
     elif args.command == "mcp":
         if args.mcp_command == "serve":
             from paygraph.mcp_server import _MCP_IMPORT_ERROR

--- a/src/paygraph/policy.py
+++ b/src/paygraph/policy.py
@@ -82,8 +82,8 @@ class PolicyEngine:
         self._monthly_spend: float = 0.0
         self._monthly_start: datetime | None = None
 
-    def _reset_daily_if_needed(self) -> None:
-        today = date.today()
+    def _reset_daily_if_needed(self, now: datetime | None = None) -> None:
+        today = now.date() if now is not None else date.today()
         if today != self._current_date:
             self._daily_spend = 0.0
             self._current_date = today
@@ -139,7 +139,7 @@ class PolicyEngine:
         """
         if now is None:
             now = datetime.now()
-        self._reset_daily_if_needed()
+        self._reset_daily_if_needed(now)
         self._reset_hourly_if_needed(now)
         self._reset_weekly_if_needed(now)
         self._reset_monthly_if_needed(now)
@@ -246,7 +246,7 @@ class PolicyEngine:
         """
         if now is None:
             now = datetime.now()
-        self._reset_daily_if_needed()
+        self._reset_daily_if_needed(now)
         self._daily_spend += amount
         if self.policy.hourly_budget is not None:
             self._reset_hourly_if_needed(now)

--- a/src/paygraph/simulator.py
+++ b/src/paygraph/simulator.py
@@ -1,0 +1,236 @@
+"""Policy simulator — replay an audit JSONL log against a candidate SpendPolicy.
+
+The simulator answers the question *"what would have happened if this new
+policy had been live last week?"* by reading the existing audit log,
+re-evaluating each historical request against a candidate ``SpendPolicy``,
+and reporting the delta per record (unchanged, flipped to approved, flipped
+to denied, or denial-reason changed).
+
+Cumulative state (daily / hourly / weekly / monthly budgets) is reconstructed
+by replaying records in chronological order through a fresh ``PolicyEngine``,
+using the engine's existing ``now=`` kwarg so the wall clock is irrelevant.
+
+Limitations:
+- Budget reconstruction only counts rows that were originally approved (and
+  still approve under the candidate policy). Originally-denied rows never
+  consumed budget, so re-counting them would inflate cumulative totals.
+  Pass ``only_approved=False`` to also re-check denied rows for reporting,
+  without affecting the budget reconstruction.
+- ``mcc_filter`` is a no-op in the live engine today, so it's also a no-op
+  during replay.
+"""
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+
+from paygraph.policy import PolicyEngine, PolicyResult, SpendPolicy
+
+UNCHANGED = "unchanged"
+FLIPPED_TO_DENIED = "approved->denied"
+FLIPPED_TO_APPROVED = "denied->approved"
+DENIAL_REASON_CHANGED = "denial_reason_changed"
+
+_ORIGINAL_APPROVED_RESULTS = {"approved", "pending_approval"}
+
+
+@dataclass
+class ReplayOutcome:
+    """One audit record replayed against the candidate policy."""
+
+    timestamp: str
+    amount: float
+    vendor: str
+    justification: str | None
+    original_result: str
+    original_denial_reason: str | None
+    new_result: str
+    new_denial_reason: str | None
+    delta: str
+
+
+@dataclass
+class ReplayReport:
+    """Aggregate result of replaying an audit log against a candidate policy."""
+
+    candidate_policy: dict
+    total: int
+    unchanged: int
+    flipped_to_denied: int
+    flipped_to_approved: int
+    denial_reason_changed: int
+    outcomes: list[ReplayOutcome] = field(default_factory=list)
+
+    def summary(self) -> str:
+        """Human-readable table for CLI output."""
+        lines = [
+            "Policy replay report",
+            "=" * 50,
+            f"Total records evaluated: {self.total}",
+            f"  Unchanged:             {self.unchanged}",
+            f"  Approved -> Denied:    {self.flipped_to_denied}",
+            f"  Denied   -> Approved:  {self.flipped_to_approved}",
+            f"  Denial reason changed: {self.denial_reason_changed}",
+            "",
+        ]
+        flipped = [o for o in self.outcomes if o.delta != UNCHANGED]
+        if flipped:
+            lines.append("Changed outcomes:")
+            lines.append("-" * 50)
+            for o in flipped:
+                lines.append(
+                    f"  [{o.delta}] {o.timestamp}  ${o.amount:.2f} -> {o.vendor}"
+                )
+                if o.new_denial_reason and o.new_denial_reason != o.original_denial_reason:
+                    lines.append(f"      new reason: {o.new_denial_reason}")
+        return "\n".join(lines)
+
+
+class PolicySimulator:
+    """Replay an audit JSONL log against a candidate ``SpendPolicy``.
+
+    Example:
+        ```python
+        from paygraph import PolicySimulator, SpendPolicy
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=10.0))
+        report = sim.replay_file("paygraph_audit.jsonl")
+        print(report.summary())
+        ```
+    """
+
+    def __init__(self, candidate_policy: SpendPolicy) -> None:
+        """Initialize the simulator.
+
+        Args:
+            candidate_policy: The ``SpendPolicy`` to evaluate historical
+                requests against.
+        """
+        self.candidate_policy = candidate_policy
+
+    def replay_file(
+        self,
+        audit_path: str,
+        *,
+        only_approved: bool = True,
+    ) -> ReplayReport:
+        """Replay records from a JSONL audit file.
+
+        Args:
+            audit_path: Path to a paygraph audit JSONL log file.
+            only_approved: If True (default), only previously-approved rows
+                consume reconstructed budget. If False, originally-denied
+                rows are also counted toward cumulative totals during replay
+                (rarely what you want — original denied spends never hit
+                the budget).
+
+        Returns:
+            A ``ReplayReport`` with per-record outcomes and aggregate counts.
+        """
+        with open(audit_path) as f:
+            records = [json.loads(line) for line in f if line.strip()]
+        return self.replay(records, only_approved=only_approved)
+
+    def replay(
+        self,
+        records: list[dict],
+        *,
+        only_approved: bool = True,
+    ) -> ReplayReport:
+        """Replay an in-memory list of audit records (raw dicts).
+
+        Records are sorted by ``timestamp`` so cumulative state is
+        reconstructed in chronological order, independent of the order they
+        were passed in.
+        """
+        records = sorted(records, key=lambda r: r["timestamp"])
+        engine = PolicyEngine(self.candidate_policy)
+        outcomes: list[ReplayOutcome] = []
+
+        for row in records:
+            ts = _parse_timestamp(row["timestamp"])
+            new_result = engine.evaluate(
+                amount=row["amount"],
+                vendor=row["vendor"],
+                justification=row.get("justification"),
+                now=ts,
+            )
+            originally_approved = row["policy_result"] in _ORIGINAL_APPROVED_RESULTS
+            should_commit = new_result.approved and (
+                originally_approved or not only_approved
+            )
+            if should_commit:
+                engine.commit_spend(row["amount"], now=ts)
+
+            outcomes.append(_build_outcome(row, new_result))
+
+        return _summarize(outcomes, self.candidate_policy)
+
+
+def _parse_timestamp(value: str) -> datetime:
+    # AuditRecord.now() writes datetime.now(timezone.utc).isoformat(), which
+    # fromisoformat handles natively on 3.11+. The "Z" suffix some upstream
+    # tools emit is not produced by our logger but we accept it defensively.
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+def _build_outcome(row: dict, new: PolicyResult) -> ReplayOutcome:
+    original_result = row["policy_result"]
+    original_denial_reason = row.get("denial_reason")
+    new_result_str = "approved" if new.approved else "denied"
+    originally_approved = original_result in _ORIGINAL_APPROVED_RESULTS
+
+    if originally_approved and not new.approved:
+        delta = FLIPPED_TO_DENIED
+    elif (not originally_approved) and new.approved:
+        delta = FLIPPED_TO_APPROVED
+    elif (not originally_approved) and (not new.approved) and (
+        new.denial_reason != original_denial_reason
+    ):
+        delta = DENIAL_REASON_CHANGED
+    else:
+        delta = UNCHANGED
+
+    return ReplayOutcome(
+        timestamp=row["timestamp"],
+        amount=row["amount"],
+        vendor=row["vendor"],
+        justification=row.get("justification"),
+        original_result=original_result,
+        original_denial_reason=original_denial_reason,
+        new_result=new_result_str,
+        new_denial_reason=new.denial_reason,
+        delta=delta,
+    )
+
+
+def _summarize(
+    outcomes: list[ReplayOutcome], candidate_policy: SpendPolicy
+) -> ReplayReport:
+    return ReplayReport(
+        candidate_policy=asdict(candidate_policy),
+        total=len(outcomes),
+        unchanged=sum(1 for o in outcomes if o.delta == UNCHANGED),
+        flipped_to_denied=sum(1 for o in outcomes if o.delta == FLIPPED_TO_DENIED),
+        flipped_to_approved=sum(
+            1 for o in outcomes if o.delta == FLIPPED_TO_APPROVED
+        ),
+        denial_reason_changed=sum(
+            1 for o in outcomes if o.delta == DENIAL_REASON_CHANGED
+        ),
+        outcomes=outcomes,
+    )
+
+
+def load_policy_json(path: str) -> SpendPolicy:
+    """Load a ``SpendPolicy`` from a JSON file.
+
+    Unknown fields are ignored so a snapshot written by a newer paygraph
+    version can still be loaded by an older one.
+    """
+    with open(path) as f:
+        data = json.load(f)
+    allowed = {f.name for f in SpendPolicy.__dataclass_fields__.values()}
+    return SpendPolicy(**{k: v for k, v in data.items() if k in allowed})

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from functools import cached_property
 
 from paygraph.audit import AuditLogger, AuditRecord
@@ -106,6 +107,10 @@ class AgentWallet:
             return name, gw
         return None
 
+    def _policy_snapshot(self) -> dict:
+        """Return the active SpendPolicy as a dict for audit-record snapshotting."""
+        return asdict(self.policy_engine.policy)
+
     def _execute_with_policy(
         self,
         gateway_name: str,
@@ -145,6 +150,7 @@ class AgentWallet:
                     policy_result="denied",
                     denial_reason=result.denial_reason,
                     checks_passed=result.checks_passed,
+                    policy_snapshot=self._policy_snapshot(),
                 )
             )
             raise PolicyViolationError(result.denial_reason)
@@ -164,6 +170,7 @@ class AgentWallet:
                     justification=justification,
                     policy_result="pending_approval",
                     checks_passed=result.checks_passed,
+                    policy_snapshot=self._policy_snapshot(),
                 )
             )
             try:
@@ -187,6 +194,7 @@ class AgentWallet:
                     policy_result="denied",
                     denial_reason="Human denied the spend request",
                     checks_passed=result.checks_passed,
+                    policy_snapshot=self._policy_snapshot(),
                 )
             )
             raise
@@ -200,6 +208,7 @@ class AgentWallet:
                     policy_result="denied",
                     denial_reason=f"Gateway error: {e}",
                     checks_passed=result.checks_passed,
+                    policy_snapshot=self._policy_snapshot(),
                 )
             )
             raise GatewayError(str(e)) from e
@@ -217,6 +226,7 @@ class AgentWallet:
                 checks_passed=result.checks_passed,
                 gateway_ref=spend_result.gateway_ref,
                 gateway_type=spend_result.gateway_type,
+                policy_snapshot=self._policy_snapshot(),
             )
         )
 
@@ -253,6 +263,7 @@ class AgentWallet:
                     policy_result="denied",
                     denial_reason=result.denial_reason,
                     checks_passed=result.checks_passed,
+                    policy_snapshot=self._policy_snapshot(),
                 )
             )
             raise PolicyViolationError(result.denial_reason)
@@ -273,6 +284,7 @@ class AgentWallet:
                     policy_result="denied",
                     denial_reason="Human denied the x402 payment request",
                     checks_passed=result.checks_passed,
+                    policy_snapshot=self._policy_snapshot(),
                 )
             )
             raise
@@ -286,6 +298,7 @@ class AgentWallet:
                     policy_result="denied",
                     denial_reason=f"Gateway error: {e}",
                     checks_passed=result.checks_passed,
+                    policy_snapshot=self._policy_snapshot(),
                 )
             )
             raise GatewayError(str(e)) from e
@@ -302,6 +315,7 @@ class AgentWallet:
                 checks_passed=result.checks_passed,
                 gateway_ref=spend_result.gateway_ref,
                 gateway_type=spend_result.gateway_type,
+                policy_snapshot=self._policy_snapshot(),
             )
         )
 
@@ -412,6 +426,7 @@ class AgentWallet:
                     justification=justification,
                     policy_result="denied",
                     denial_reason=str(e),
+                    policy_snapshot=self._policy_snapshot(),
                 )
             )
             raise
@@ -426,6 +441,7 @@ class AgentWallet:
                 policy_result="approved",
                 gateway_ref=card.gateway_ref,
                 gateway_type=card.gateway_type,
+                policy_snapshot=self._policy_snapshot(),
             )
         )
 

--- a/tests/test_cli_replay.py
+++ b/tests/test_cli_replay.py
@@ -1,0 +1,88 @@
+import json
+import tempfile
+from datetime import datetime, timezone
+
+import pytest
+
+from paygraph.audit import AuditLogger, AuditRecord
+from paygraph.cli import run_replay
+
+
+def _make_audit(amount: float = 40.0) -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+    f.close()
+    record = AuditRecord(
+        timestamp=datetime(2026, 5, 15, 12, 0, tzinfo=timezone.utc).isoformat(),
+        agent_id="default",
+        amount=amount,
+        vendor="Anthropic",
+        justification="tokens",
+        policy_result="approved",
+        denial_reason=None,
+        checks_passed=[],
+        gateway_ref="ref",
+        gateway_type="mock",
+        policy_snapshot={"max_transaction": 50.0, "daily_budget": 200.0},
+    )
+    AuditLogger(log_path=f.name, verbose=False).log(record)
+    return f.name
+
+
+def _make_policy_json(max_transaction: float = 10.0) -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+    json.dump({"max_transaction": max_transaction, "daily_budget": 100.0}, f)
+    f.close()
+    return f.name
+
+
+class TestReplayCli:
+    def test_runs_and_returns_zero_on_success(self, capsys):
+        audit = _make_audit(amount=40.0)
+        policy = _make_policy_json(max_transaction=10.0)
+
+        rc = run_replay(audit, policy, all_rows=False, as_json=False)
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert "Policy replay report" in captured.out
+        assert "Approved -> Denied:    1" in captured.out
+
+    def test_json_output_is_parseable(self, capsys):
+        audit = _make_audit(amount=40.0)
+        policy = _make_policy_json(max_transaction=10.0)
+
+        rc = run_replay(audit, policy, all_rows=False, as_json=True)
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        payload = json.loads(captured.out)
+        assert payload["total"] == 1
+        assert payload["flipped_to_denied"] == 1
+        assert payload["candidate_policy"]["max_transaction"] == 10.0
+
+    def test_missing_audit_log_returns_nonzero(self, capsys):
+        policy = _make_policy_json()
+        rc = run_replay(
+            "C:/nonexistent/audit.jsonl", policy, all_rows=False, as_json=False
+        )
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "audit log not found" in captured.err
+
+    def test_missing_policy_returns_nonzero(self, capsys):
+        audit = _make_audit()
+        rc = run_replay(
+            audit, "C:/nonexistent/policy.json", all_rows=False, as_json=False
+        )
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "policy file not found" in captured.err
+
+
+class TestReplaySubcommandArgParsing:
+    def test_replay_requires_policy_flag(self, monkeypatch):
+        from paygraph import cli as cli_mod
+
+        monkeypatch.setattr("sys.argv", ["paygraph", "replay", "audit.jsonl"])
+        with pytest.raises(SystemExit):
+            cli_mod.main()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,5 +1,4 @@
-from datetime import date
-from unittest.mock import patch
+from datetime import datetime
 
 from paygraph.policy import PolicyEngine, SpendPolicy
 
@@ -149,16 +148,15 @@ class TestDailyBudget:
 
     def test_resets_on_new_day(self):
         engine = PolicyEngine(SpendPolicy(max_transaction=100.0, daily_budget=100.0))
-        engine.evaluate(80.0, "vendor", "reason")
-        engine.commit_spend(80.0)
+        # Use the explicit ``now=`` kwarg to drive the day-rollover deterministically.
+        engine.evaluate(80.0, "vendor", "reason", now=datetime(2099, 1, 1, 12, 0))
+        engine.commit_spend(80.0, now=datetime(2099, 1, 1, 12, 0))
 
         # Simulate next day
-        tomorrow = date(2099, 1, 2)
-        with patch("paygraph.policy.date") as mock_date:
-            mock_date.today.return_value = tomorrow
-            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
-            result = engine.evaluate(80.0, "vendor", "reason")
-            assert result.approved
+        result = engine.evaluate(
+            80.0, "vendor", "reason", now=datetime(2099, 1, 2, 12, 0)
+        )
+        assert result.approved
 
 
 class TestCommitSpend:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,326 @@
+import json
+import tempfile
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+import pytest
+
+from paygraph.audit import AuditLogger, AuditRecord
+from paygraph.policy import SpendPolicy
+from paygraph.simulator import (
+    FLIPPED_TO_DENIED,
+    UNCHANGED,
+    PolicySimulator,
+    load_policy_json,
+)
+
+
+def _make_audit_path() -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+    f.close()
+    return f.name
+
+
+def _write_record(
+    path: str,
+    *,
+    timestamp: str,
+    amount: float,
+    vendor: str = "Anthropic",
+    justification: str | None = "needs tokens",
+    policy_result: str = "approved",
+    denial_reason: str | None = None,
+    policy_snapshot: dict | None = None,
+) -> None:
+    record = AuditRecord(
+        timestamp=timestamp,
+        agent_id="default",
+        amount=amount,
+        vendor=vendor,
+        justification=justification,
+        policy_result=policy_result,
+        denial_reason=denial_reason,
+        checks_passed=[],
+        gateway_ref=None,
+        gateway_type=None,
+        policy_snapshot=policy_snapshot,
+    )
+    logger = AuditLogger(log_path=path, verbose=False)
+    logger.log(record)
+
+
+def _ts(hour: int = 12, minute: int = 0, day: int = 15) -> str:
+    return datetime(2026, 5, day, hour, minute, tzinfo=timezone.utc).isoformat()
+
+
+class TestReplayBasics:
+    def test_unchanged_policy_yields_all_unchanged(self):
+        path = _make_audit_path()
+        for i in range(3):
+            _write_record(path, timestamp=_ts(hour=10 + i), amount=5.0)
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=50.0, daily_budget=200.0))
+        report = sim.replay_file(path)
+
+        assert report.total == 3
+        assert report.unchanged == 3
+        assert report.flipped_to_denied == 0
+        assert all(o.delta == UNCHANGED for o in report.outcomes)
+
+    def test_tightening_amount_cap_flips_approved_to_denied(self):
+        path = _make_audit_path()
+        _write_record(path, timestamp=_ts(hour=9), amount=40.0)
+        _write_record(path, timestamp=_ts(hour=10), amount=3.0)
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=10.0, daily_budget=200.0))
+        report = sim.replay_file(path)
+
+        assert report.flipped_to_denied == 1
+        assert report.unchanged == 1
+        flipped = next(o for o in report.outcomes if o.delta == FLIPPED_TO_DENIED)
+        assert flipped.amount == 40.0
+        assert "exceeds" in flipped.new_denial_reason.lower()
+
+    def test_loosening_amount_cap_keeps_already_approved_unchanged(self):
+        path = _make_audit_path()
+        _write_record(path, timestamp=_ts(hour=9), amount=20.0)
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=100.0, daily_budget=500.0))
+        report = sim.replay_file(path)
+
+        assert report.unchanged == 1
+        assert report.flipped_to_denied == 0
+        assert report.flipped_to_approved == 0
+
+    def test_only_approved_filter_does_not_count_denied_rows_toward_budget(self):
+        path = _make_audit_path()
+        # An originally-denied row that fits within the candidate budget
+        # individually — but if it (incorrectly) counted toward the budget,
+        # the next legitimate row would be denied.
+        _write_record(
+            path,
+            timestamp=_ts(hour=9),
+            amount=60.0,
+            policy_result="denied",
+            denial_reason="Vendor 'BadCo' is blocked",
+            vendor="BadCo",
+        )
+        _write_record(path, timestamp=_ts(hour=10), amount=60.0)
+
+        # Candidate: no vendor blocklist, daily_budget=100. Originally-denied
+        # $60 (BadCo) would still be denied by the candidate's amount budget
+        # if it leaked into _daily_spend. only_approved=True must keep it out.
+        sim = PolicySimulator(SpendPolicy(max_transaction=200.0, daily_budget=100.0))
+        report = sim.replay_file(path)
+
+        # The 10:00 Anthropic $60 must approve cleanly because the prior
+        # denied $60 didn't consume budget.
+        ten_oclock = next(o for o in report.outcomes if "10:00" in o.timestamp)
+        assert ten_oclock.new_result == "approved"
+
+    def test_all_flag_reevaluates_denied_rows_and_affects_budget(self):
+        path = _make_audit_path()
+        _write_record(
+            path,
+            timestamp=_ts(hour=9),
+            amount=80.0,
+            policy_result="denied",
+            denial_reason="Amount $80.00 exceeds limit of $50.00",
+        )
+        _write_record(path, timestamp=_ts(hour=10), amount=30.0)
+
+        # With --all and a daily_budget of 100, the resurrected $80 + the $30
+        # now blow the daily budget on the second row.
+        sim = PolicySimulator(SpendPolicy(max_transaction=1000.0, daily_budget=100.0))
+        report = sim.replay_file(path, only_approved=False)
+
+        assert report.flipped_to_approved >= 1
+        flipped_to_denied = [o for o in report.outcomes if o.delta == FLIPPED_TO_DENIED]
+        assert len(flipped_to_denied) == 1
+        assert "budget" in flipped_to_denied[0].new_denial_reason.lower()
+
+
+class TestCumulativeBudget:
+    def test_daily_budget_reconstructed_in_chronological_order(self):
+        path = _make_audit_path()
+        # Five $25 spends on the same day = $125 total.
+        for i in range(5):
+            _write_record(path, timestamp=_ts(hour=8 + i), amount=25.0)
+
+        # Candidate caps daily at $60 → first two approve, third onward denied.
+        sim = PolicySimulator(SpendPolicy(max_transaction=50.0, daily_budget=60.0))
+        report = sim.replay_file(path)
+
+        approved = [o for o in report.outcomes if o.new_result == "approved"]
+        denied = [o for o in report.outcomes if o.new_result == "denied"]
+        assert len(approved) == 2
+        assert len(denied) == 3
+        assert all("budget" in o.new_denial_reason.lower() for o in denied)
+
+    def test_records_out_of_order_are_sorted_by_timestamp(self):
+        path = _make_audit_path()
+        # Write out of order on purpose.
+        _write_record(path, timestamp=_ts(hour=14), amount=25.0)
+        _write_record(path, timestamp=_ts(hour=9), amount=25.0)
+        _write_record(path, timestamp=_ts(hour=11), amount=25.0)
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=50.0, daily_budget=60.0))
+        report = sim.replay_file(path)
+
+        # First two chronologically should approve ($50 of $60), the 14:00 one denies.
+        outcomes_by_ts = sorted(report.outcomes, key=lambda o: o.timestamp)
+        assert outcomes_by_ts[0].new_result == "approved"
+        assert outcomes_by_ts[1].new_result == "approved"
+        assert outcomes_by_ts[2].new_result == "denied"
+
+    def test_different_days_reset_daily_budget(self):
+        path = _make_audit_path()
+        _write_record(path, timestamp=_ts(day=15, hour=10), amount=50.0)
+        _write_record(path, timestamp=_ts(day=16, hour=10), amount=50.0)
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=100.0, daily_budget=60.0))
+        report = sim.replay_file(path)
+
+        assert all(o.new_result == "approved" for o in report.outcomes)
+
+
+class TestSnapshotForwardCompat:
+    def test_rows_without_policy_snapshot_still_replay(self):
+        path = _make_audit_path()
+        # Manually write a row in the legacy format (no policy_snapshot field).
+        legacy = {
+            "timestamp": _ts(hour=10),
+            "agent_id": "default",
+            "amount": 5.0,
+            "vendor": "Anthropic",
+            "justification": "tokens",
+            "policy_result": "approved",
+            "denial_reason": None,
+            "checks_passed": [],
+            "gateway_ref": "ref",
+            "gateway_type": "mock",
+        }
+        with open(path, "w") as f:
+            f.write(json.dumps(legacy) + "\n")
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=10.0, daily_budget=100.0))
+        report = sim.replay_file(path)
+
+        assert report.total == 1
+        assert report.unchanged == 1
+
+
+class TestReportShape:
+    def test_summary_counts_match_outcomes(self):
+        path = _make_audit_path()
+        _write_record(path, timestamp=_ts(hour=9), amount=40.0)
+        _write_record(path, timestamp=_ts(hour=10), amount=3.0)
+        _write_record(
+            path,
+            timestamp=_ts(hour=11),
+            amount=2.0,
+            policy_result="denied",
+            denial_reason="Justification is required but was not provided",
+            justification=None,
+        )
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=10.0, daily_budget=200.0))
+        report = sim.replay_file(path)
+
+        assert report.total == 3
+        assert (
+            report.unchanged
+            + report.flipped_to_denied
+            + report.flipped_to_approved
+            + report.denial_reason_changed
+            == report.total
+        )
+
+    def test_report_serializable_to_json(self):
+        path = _make_audit_path()
+        _write_record(path, timestamp=_ts(hour=9), amount=5.0)
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=10.0))
+        report = sim.replay_file(path)
+
+        # Round-trip through JSON to confirm everything is serializable.
+        blob = json.dumps(asdict(report))
+        parsed = json.loads(blob)
+        assert parsed["total"] == 1
+        assert parsed["candidate_policy"]["max_transaction"] == 10.0
+
+    def test_summary_string_is_human_readable(self):
+        path = _make_audit_path()
+        _write_record(path, timestamp=_ts(hour=9), amount=40.0)
+
+        sim = PolicySimulator(SpendPolicy(max_transaction=10.0))
+        report = sim.replay_file(path)
+        summary = report.summary()
+        assert "Total records evaluated: 1" in summary
+        assert "Approved -> Denied:    1" in summary
+
+
+class TestLoadPolicyJson:
+    def test_loads_known_fields(self):
+        f = tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+        json.dump({"max_transaction": 7.5, "daily_budget": 99.0}, f)
+        f.close()
+
+        policy = load_policy_json(f.name)
+        assert policy.max_transaction == 7.5
+        assert policy.daily_budget == 99.0
+
+    def test_ignores_unknown_fields_for_forward_compat(self):
+        f = tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+        json.dump({"max_transaction": 5.0, "future_field_v3": "ignored"}, f)
+        f.close()
+
+        policy = load_policy_json(f.name)
+        assert policy.max_transaction == 5.0
+
+
+class TestReplayWithRealAuditLog:
+    """End-to-end: spin up a wallet, generate real audit rows, replay them."""
+
+    def test_round_trip_against_unchanged_policy(self):
+        from paygraph.gateways.mock import MockGateway
+        from paygraph.wallet import AgentWallet
+
+        audit_path = _make_audit_path()
+        policy = SpendPolicy(max_transaction=50.0, daily_budget=200.0)
+        wallet = AgentWallet(
+            gateways=MockGateway(auto_approve=True),
+            policy=policy,
+            log_path=audit_path,
+            verbose=False,
+        )
+        for amt in (5.0, 12.0, 7.0):
+            wallet.request_spend(amt, "Anthropic", "tokens")
+        with pytest.raises(Exception):
+            wallet.request_spend(500.0, "Anthropic", "too much")
+
+        sim = PolicySimulator(policy)
+        report = sim.replay_file(audit_path)
+
+        assert report.total == 4
+        assert report.unchanged == 4
+
+    def test_policy_snapshot_is_persisted_in_real_audit_log(self):
+        from paygraph.gateways.mock import MockGateway
+        from paygraph.wallet import AgentWallet
+
+        audit_path = _make_audit_path()
+        wallet = AgentWallet(
+            gateways=MockGateway(auto_approve=True),
+            policy=SpendPolicy(max_transaction=42.0, daily_budget=99.0),
+            log_path=audit_path,
+            verbose=False,
+        )
+        wallet.request_spend(5.0, "Anthropic", "tokens")
+
+        with open(audit_path) as f:
+            row = json.loads(f.readline())
+
+        assert row["policy_snapshot"] is not None
+        assert row["policy_snapshot"]["max_transaction"] == 42.0
+        assert row["policy_snapshot"]["daily_budget"] == 99.0


### PR DESCRIPTION
## Summary

- Add `policy_snapshot: dict | None` field to `AuditRecord` so every log line carries the active SpendPolicy. Backwards-compatible (nullable, defaults to
  None; old logs replay fine).

- New `paygraph.simulator.PolicySimulator` replays an audit JSONL against a candidate SpendPolicy. Reconstructs cumulative spend state in chronological
  order via the engine's `now=` kwarg. Returns a `ReplayReport` with per-record deltas (unchanged / flipped / denial-reason-changed).

- New `paygraph replay <log> --policy <policy.json>` CLI subcommand with `--all` (re-check denied rows) and `--json` (machine-readable output).

- Small engine change: `PolicyEngine._reset_daily_if_needed` now accepts `now=` like the other resetters, so the daily window is driven by the same injected clock during replay. One existing test updated to use the `now=` kwarg instead of patching `paygraph.policy.date`. No production behavior change for callers that don't pass `now=`.

Closes #8.

## Test plan

- [x] uv run pytest -q  (213 pass)
- [x] uv run ruff check src tests
- [x] paygraph demo && paygraph replay paygraph_audit.jsonl --policy tighter.json