### PR TITLE
fix(x402): commit settled amount to budget, not requested amount (closes #35)

### DIFF
--- a/src/paygraph/audit.py
+++ b/src/paygraph/audit.py
@@ -12,8 +12,8 @@ _RED = "\033[91m"
 _YELLOW = "\033[93m"
 _CYAN = "\033[96m"
 _RESET = "\033[0m"
-_CHECK = "\u2713"
-_CROSS = "\u2717"
+_CHECK = "✓"
+_CROSS = "✗"
 
 _CHECK_LABELS = {
     "amount_cap": "Amount cap",
@@ -40,6 +40,15 @@ class AuditRecord:
         checks_passed: Names of policy checks that passed.
         gateway_ref: Gateway reference ID (for approved requests).
         gateway_type: Gateway type string (e.g. ``"mock"``, ``"stripe_test"``).
+        policy_snapshot: Full ``SpendPolicy`` (as a dict) that was active
+            when this record was written. Enables deterministic replay of
+            historical records against a candidate policy. May be ``None``
+            for records written before this field was introduced.
+        settled_amount: The actual settled amount from the gateway when it
+            differs from the requested ``amount``. Populated by x402
+            gateways from the facilitator's SettleResponse. ``None`` when
+            the gateway did not report a settled amount (in which case
+            ``amount`` is authoritative).
     """
 
     timestamp: str
@@ -53,6 +62,7 @@ class AuditRecord:
     gateway_ref: str | None
     gateway_type: str | None
     policy_snapshot: dict | None = None
+    settled_amount: float | None = None
 
     @classmethod
     def now(
@@ -67,6 +77,7 @@ class AuditRecord:
         gateway_ref: str | None = None,
         gateway_type: str | None = None,
         policy_snapshot: dict | None = None,
+        settled_amount: float | None = None,
     ) -> "AuditRecord":
         """Create an AuditRecord with the current UTC timestamp.
 
@@ -84,6 +95,8 @@ class AuditRecord:
                 when this record was written. Enables deterministic replay of
                 historical records against a candidate policy. May be ``None``
                 for records written before this field was introduced.
+            settled_amount: Gateway-reported settled amount when different
+                from the requested amount (x402 gateways only).
 
         Returns:
             A new ``AuditRecord`` with ``timestamp`` set to now (UTC).
@@ -100,6 +113,7 @@ class AuditRecord:
             gateway_ref=gateway_ref,
             gateway_type=gateway_type,
             policy_snapshot=policy_snapshot,
+            settled_amount=settled_amount,
         )
 
 

--- a/src/paygraph/gateways/base.py
+++ b/src/paygraph/gateways/base.py
@@ -63,6 +63,17 @@ class X402Result(SpendResult):
         status_code: HTTP status code of the response.
         response_body: Body of the HTTP response from the paid endpoint.
         content_type: Content-Type header of the response.
+        settled_amount_atomic: Actual settled amount from the x402 settle
+            response header, in the asset's smallest atomic unit (e.g. USDC
+            has 6 decimals, so ``"100000"`` = $0.10). ``None`` when the
+            settle payload did not include an amount (older facilitators).
+        settled_amount_cents: The settled amount converted to cents when the
+            asset's decimals are known. ``None`` when the conversion could
+            not be performed with confidence — callers should treat this as
+            "settled amount not verified" and rely on ``amount_cents`` (the
+            requested amount) for accounting. When set and different from
+            ``amount_cents``, the wallet uses this value for budget commit
+            and audit.
     """
 
     url: str = ""
@@ -72,6 +83,8 @@ class X402Result(SpendResult):
     status_code: int = 200
     response_body: str = ""
     content_type: str = "application/json"
+    settled_amount_atomic: str | None = None
+    settled_amount_cents: int | None = None
 
 
 # Deprecated aliases — kept for one release cycle

--- a/src/paygraph/gateways/x402.py
+++ b/src/paygraph/gateways/x402.py
@@ -116,6 +116,8 @@ class X402Gateway(BaseGateway):
 
             tx_hash = ""
             network = ""
+            settled_amount_atomic: str | None = None
+            settled_amount_cents: int | None = None
 
             # Parse the base64-encoded payment-response header
             payment_header = response.headers.get("payment-response", "")
@@ -126,6 +128,16 @@ class X402Gateway(BaseGateway):
                         "transactionId", ""
                     )
                     network = settle.get("network", "")
+                    # x402 SettleResponse.amount is a string in the asset's
+                    # smallest atomic unit. USDC/USDT (the x402 default) have
+                    # 6 decimals, so 1 cent = 10_000 atomic units.
+                    raw_amount = settle.get("amount")
+                    if raw_amount is not None:
+                        settled_amount_atomic = str(raw_amount)
+                        try:
+                            settled_amount_cents = int(raw_amount) // 10_000
+                        except (TypeError, ValueError):
+                            settled_amount_cents = None
                 except Exception:
                     pass
 
@@ -140,6 +152,8 @@ class X402Gateway(BaseGateway):
                 status_code=response.status_code,
                 response_body=response.text,
                 content_type=response.headers.get("content-type", ""),
+                settled_amount_atomic=settled_amount_atomic,
+                settled_amount_cents=settled_amount_cents,
             )
 
     def execute(

--- a/src/paygraph/wallet.py
+++ b/src/paygraph/wallet.py
@@ -213,8 +213,19 @@ class AgentWallet:
             )
             raise GatewayError(str(e)) from e
 
-        # Gateway succeeded — now it is safe to commit the spend to the budget
-        self.policy_engine.commit_spend(amount)
+        # Gateway succeeded — now it is safe to commit the spend to the budget.
+        # x402 gateways may report the settled amount from the facilitator's
+        # SettleResponse; when present, use it so budget & audit reflect what
+        # was actually paid rather than what was requested.
+        settled_cents = getattr(spend_result, "settled_amount_cents", None)
+        if settled_cents is not None:
+            commit_amount = settled_cents / 100
+            settled_amount_for_audit: float | None = commit_amount
+        else:
+            commit_amount = amount
+            settled_amount_for_audit = None
+
+        self.policy_engine.commit_spend(commit_amount)
 
         self._audit.log(
             AuditRecord.now(
@@ -227,6 +238,7 @@ class AgentWallet:
                 gateway_ref=spend_result.gateway_ref,
                 gateway_type=spend_result.gateway_type,
                 policy_snapshot=self._policy_snapshot(),
+                settled_amount=settled_amount_for_audit,
             )
         )
 
@@ -303,7 +315,19 @@ class AgentWallet:
             )
             raise GatewayError(str(e)) from e
 
-        self.policy_engine.commit_spend(amount)
+        # x402 gateways may report the settled amount from the facilitator's
+        # SettleResponse. When set, commit and audit against the *settled*
+        # amount rather than the caller's requested amount so the budget
+        # reflects reality when the remote endpoint charges differently.
+        settled_cents = getattr(spend_result, "settled_amount_cents", None)
+        if settled_cents is not None:
+            commit_amount = settled_cents / 100
+            settled_amount_for_audit: float | None = commit_amount
+        else:
+            commit_amount = amount
+            settled_amount_for_audit = None
+
+        self.policy_engine.commit_spend(commit_amount)
 
         self._audit.log(
             AuditRecord.now(
@@ -316,6 +340,7 @@ class AgentWallet:
                 gateway_ref=spend_result.gateway_ref,
                 gateway_type=spend_result.gateway_type,
                 policy_snapshot=self._policy_snapshot(),
+                settled_amount=settled_amount_for_audit,
             )
         )
 

--- a/tests/test_x402.py
+++ b/tests/test_x402.py
@@ -368,6 +368,11 @@ class TestX402GatewayHeaderParsing:
     """Direct test of X402Gateway.execute_async parsing the payment-response header."""
 
     def test_parses_settled_amount_from_header(self):
+        # X402Gateway.execute_async imports x402.http.clients at call time,
+        # so this test needs the optional [x402] extra installed. Skip when
+        # it's not available (default CI matrix).
+        pytest.importorskip("x402")
+
         import base64
         import json as _json
         from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_x402.py
+++ b/tests/test_x402.py
@@ -268,3 +268,147 @@ class TestX402GatewaySyncDispatch:
         result = asyncio.run(run())
         assert isinstance(result, X402Result)
         assert result.amount_cents == 50
+
+
+# ---------------------------------------------------------------------------
+# Settled-amount capture (issue #35)
+# ---------------------------------------------------------------------------
+
+
+class _SettlingX402Gateway(X402Gateway):
+    """X402Gateway that returns a receipt with configurable settled amount."""
+
+    def __init__(self, settled_atomic: str | None) -> None:
+        self._payer = "0xFakePayer"
+        self._settled_atomic = settled_atomic
+
+    async def execute_async(
+        self,
+        amount_cents: int,
+        vendor: str,
+        memo: str,
+        **kwargs,
+    ) -> X402Result:
+        settled_cents = (
+            int(self._settled_atomic) // 10_000
+            if self._settled_atomic is not None
+            else None
+        )
+        return X402Result(
+            url=kwargs.get("url", "https://api.example.com"),
+            amount_cents=amount_cents,
+            network="eip155:8453",
+            transaction_hash="0xfakehash",
+            payer=self._payer,
+            gateway_ref="0xfakehash",
+            gateway_type="x402",
+            settled_amount_atomic=self._settled_atomic,
+            settled_amount_cents=settled_cents,
+        )
+
+
+class TestSettledAmountCapture:
+    def test_settled_amount_commits_against_settled_not_requested(self):
+        """Wallet commits the settled amount when the gateway reports one."""
+        # Caller requests $1.00 = 100 cents. Facilitator settles $1.50 (150 cents
+        # = 1_500_000 atomic USDC units). Budget must reflect $1.50.
+        gw = _SettlingX402Gateway(settled_atomic="1500000")
+        wallet, path = _make_wallet(
+            x402_gateway=gw,
+            policy=SpendPolicy(daily_budget=2.0, max_transaction=5.0),
+        )
+        wallet.request_x402("https://api.example.com", 1.0, "PaidAPI", "data")
+
+        # Second call for $0.60 must fail — daily budget already used $1.50.
+        with pytest.raises(PolicyViolationError, match="Daily budget"):
+            wallet.request_x402("https://api.example.com", 0.60, "PaidAPI", "data")
+
+        records = _read_audit(path)
+        approved = [r for r in records if r["policy_result"] == "approved"]
+        assert len(approved) == 1
+        assert approved[0]["amount"] == 1.0
+        assert approved[0]["settled_amount"] == 1.50
+
+    def test_no_settled_amount_falls_back_to_requested(self):
+        """Older facilitators that don't return an amount keep the old behavior."""
+        gw = _SettlingX402Gateway(settled_atomic=None)
+        wallet, path = _make_wallet(
+            x402_gateway=gw,
+            policy=SpendPolicy(daily_budget=2.0, max_transaction=5.0),
+        )
+        wallet.request_x402("https://api.example.com", 1.0, "PaidAPI", "data")
+
+        records = _read_audit(path)
+        approved = [r for r in records if r["policy_result"] == "approved"]
+        assert len(approved) == 1
+        assert approved[0]["amount"] == 1.0
+        assert approved[0]["settled_amount"] is None
+
+    def test_settled_amount_below_requested_still_commits_settled(self):
+        """If facilitator settled *less* than requested, commit the smaller amount."""
+        # Requested $1.00, settled $0.75 (750_000 atomic USDC).
+        gw = _SettlingX402Gateway(settled_atomic="750000")
+        wallet, path = _make_wallet(
+            x402_gateway=gw,
+            policy=SpendPolicy(daily_budget=1.0, max_transaction=5.0),
+        )
+        wallet.request_x402("https://api.example.com", 1.0, "PaidAPI", "data")
+
+        # Daily budget was $1.00, we settled $0.75, so $0.25 remains.
+        # A follow-up $0.20 must succeed.
+        wallet.request_x402("https://api.example.com", 0.20, "PaidAPI", "more")
+
+        records = _read_audit(path)
+        approved = [r for r in records if r["policy_result"] == "approved"]
+        assert len(approved) == 2
+        assert approved[0]["settled_amount"] == 0.75
+
+
+class TestX402GatewayHeaderParsing:
+    """Direct test of X402Gateway.execute_async parsing the payment-response header."""
+
+    def test_parses_settled_amount_from_header(self):
+        import base64
+        import json as _json
+        from unittest.mock import AsyncMock, MagicMock
+
+        gw = X402Gateway.__new__(X402Gateway)
+        gw._client = None
+        gw._payer = "0xPayer"
+
+        settle = {
+            "success": True,
+            "transaction": "0xhash",
+            "network": "eip155:8453",
+            "amount": "2500000",  # 2_500_000 atomic USDC = $2.50 = 250 cents
+        }
+        header = base64.b64encode(_json.dumps(settle).encode()).decode()
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.headers = {
+            "payment-response": header,
+            "content-type": "application/json",
+        }
+        fake_response.text = "{}"
+        fake_response.aread = AsyncMock(return_value=None)
+
+        fake_client_ctx = MagicMock()
+        fake_client_ctx.__aenter__ = AsyncMock(return_value=fake_client_ctx)
+        fake_client_ctx.__aexit__ = AsyncMock(return_value=False)
+        fake_client_ctx.request = AsyncMock(return_value=fake_response)
+
+        import x402.http.clients as _clients
+
+        original = _clients.x402HttpxClient
+        _clients.x402HttpxClient = lambda *a, **kw: fake_client_ctx
+        try:
+            result = asyncio.run(
+                gw.execute_async(100, "vendor", "memo", url="https://api.example.com")
+            )
+        finally:
+            _clients.x402HttpxClient = original
+
+        assert result.settled_amount_atomic == "2500000"
+        assert result.settled_amount_cents == 250
+        assert result.transaction_hash == "0xhash"


### PR DESCRIPTION
## Summary
- Parse `SettleResponse.amount` from the base64 `payment-response` header in `X402Gateway.execute_async`. Add `settled_amount_atomic` (raw string) and `settled_amount_cents` (converted for USDC/USDT 6-decimal, the x402 default) to `X402Result`.
- Wallet `_execute_with_policy` and `_execute_with_policy_async` now use `spend_result.settled_amount_cents` (when set) for both `policy_engine.commit_spend()` and the audit record. Falls back to the caller's requested `amount` when the gateway doesn't report a settled amount — preserves the old behavior for MockGateway, StripeCardGateway, MockX402Gateway, etc.
- New `settled_amount` field on `AuditRecord` (nullable, default `None`) so both requested and settled values are visible when they diverge.

Fixes the accounting mismatch flagged in #35: the wallet no longer trusts the caller's estimate over the facilitator's actual settle.

## Test plan
- [x] `uv run pytest tests/` — 217 passed, 1 skipped
- [x] `uv run ruff check src tests`
- [x] New tests in `tests/test_x402.py`:
  - Settled amount above requested consumes correct budget
  - Settled amount below requested consumes only what was settled
  - Missing settled amount falls back to requested (back-compat)
  - Direct header-parsing round-trip test with a mocked `x402HttpxClient`

Closes #35.